### PR TITLE
fix: add apt update and apt dist-update with reboot/notification

### DIFF
--- a/ansible/update/upd-apt-dist.yaml
+++ b/ansible/update/upd-apt-dist.yaml
@@ -1,0 +1,33 @@
+- hosts: "{{ hosts }}"
+  become: true
+  tasks:
+    - name: Update cache and upgrade apt packages
+      ansible.builtin.apt:
+        update_cache: true # Equivalent to 'sudo apt update' to update the cache
+        upgrade: dist # Equivalent to 'sudo apt dist-upgrade -y' to update any packages and the Linux kernel
+        autoremove: yes # Runs with the '--autoremove' flag to remove orphaned dependencies
+    - name: Check if system reboot is required
+      become: true
+      stat:
+        path: /var/run/reboot-required
+      register: reboot_required
+    - name: Print reboot message
+      ansible.builtin.debug:
+        msg: "System reboot is required. Preparing to reboot..."
+      when: reboot_required.stat.exists
+    - name: Reboot the machine if required
+      ansible.builtin.reboot:
+        reboot_timeout: 3600
+      when: reboot_required.stat.exists == true
+      register: system_rebooted
+    # You can put an 'ansible.builtin.uri' task here to send a Discord notification if the system was rebooted successfully
+    # - name: Send Discord message when reboot was completed
+    #   uri:
+    #     url: "your-webhook"
+    #     method: POST
+    #     body_format: json
+    #     body: '{"content": "{{ inventory_hostname }} has had its distro upgraded and was rebooted successfully."}'
+    #     headers:
+    #       Content-Type: application/json
+    #     status_code: 204
+    #   when: system_rebooted.changed

--- a/ansible/update/upd-apt.yaml
+++ b/ansible/update/upd-apt.yaml
@@ -1,0 +1,29 @@
+- hosts: "{{ hosts }}"
+  become: true
+  tasks:
+    - name: Update cache and upgrade apt packages
+      ansible.builtin.apt:
+        update_cache: true # Equivalent to 'sudo apt update' to update the cache
+        cache_valid_time: 7200 # Don't update cache if it was updates less than 3 hours ago
+        upgrade: yes # Equivalent to 'sudo apt upgrade -y' to update any packages
+        autoremove: yes # Runs with the '--autoremove' flag to remove orphaned dependencies
+    - name: Check if system reboot is required
+      become: true
+      stat:
+        path: /var/run/reboot-required
+      register: reboot_required
+    - name: Print reboot message
+      ansible.builtin.debug:
+        msg: "System reboot is required"
+      when: reboot_required.stat.exists
+    # You can put an 'ansible.builtin.uri' task here to send a Discord notification if the system needs rebooted
+    # - name: Send Discord message when reboot is required
+    #   uri:
+    #     url: "your-webhook"
+    #     method: POST
+    #     body_format: json
+    #     body: '{"content": "{{ inventory_hostname }} has had its packages upgraded and needs to be rebooted."}'
+    #     headers:
+    #       Content-Type: application/json
+    #     status_code: 204
+    #   when: reboot_required.stat.exists


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will help the moderators review your PR. -->

- [x] My pull request has a descriptive title. (unlike `Update index.md`). Check [this](https://www.conventionalcommits.org/en/v1.0.0/) guide regarding titles.
- [x] If applicable, I have tested these changes.
Tested on four machines running Ubuntu Server, one of which upgraded successfully with notification. The other three updated packages successfully, skipping the notification as no reboot was required.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

N/A

<!-- You can add additional description of changes below this line -->
upd-apt.yaml: Adds the tasks to update packages with an optional Discord notification if the system needs rebooted after updates have completed
upd-apt-dist.yaml: Adds dist-upgrade functionality with automatic reboot if required and optional Discord notification upon successful reboot