### PR TITLE
fix: ensure `hosts` is always defined

### DIFF
--- a/ansible/configuration/fail2ban/config-f2b-protect-sshd.yaml
+++ b/ansible/configuration/fail2ban/config-f2b-protect-sshd.yaml
@@ -1,6 +1,6 @@
 ---
 - name: install fail2ban and configure sshd
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
   - name: install fail2ban

--- a/ansible/configuration/ssh/config-add-sshkey.yaml
+++ b/ansible/configuration/ssh/config-add-sshkey.yaml
@@ -1,6 +1,6 @@
 ---
 - name: add ssh key
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
   - name: install public keys

--- a/ansible/deployment/portainer/deploy-portainer.yaml
+++ b/ansible/deployment/portainer/deploy-portainer.yaml
@@ -1,6 +1,6 @@
 ---
 - name: deploy portainer-ce latest
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   become_user: "{{ lookup('env','USER') }}"
   tasks:

--- a/ansible/deployment/traefik/deploy-traefik.yaml
+++ b/ansible/deployment/traefik/deploy-traefik.yaml
@@ -1,6 +1,6 @@
 ---
 - name: deploy traefik v2.5
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
   - name: deploy traefik

--- a/ansible/installation/inst-core.yaml
+++ b/ansible/installation/inst-core.yaml
@@ -1,5 +1,5 @@
 - name: install core packages
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
   - name: install core packages

--- a/ansible/installation/inst-docker-ubuntu.yaml
+++ b/ansible/installation/inst-docker-ubuntu.yaml
@@ -1,6 +1,6 @@
 ---
 - name: install docker
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
     - name: install docker dependencies

--- a/ansible/installation/inst-microk8s.yaml
+++ b/ansible/installation/inst-microk8s.yaml
@@ -1,6 +1,6 @@
 ---
 - name: install microk8s
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
     - name: install microk8s

--- a/ansible/installation/inst-vm-core.yaml
+++ b/ansible/installation/inst-vm-core.yaml
@@ -1,6 +1,6 @@
 ---
 - name: install core packages for virtual machines
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
   - name: install packages

--- a/ansible/installation/inst-wireguard.yaml
+++ b/ansible/installation/inst-wireguard.yaml
@@ -1,6 +1,6 @@
 ---
 - name: install wireguard
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
     - name: install wireguard

--- a/ansible/installation/inst-zsh.yaml
+++ b/ansible/installation/inst-zsh.yaml
@@ -1,6 +1,6 @@
 ---
 - name: install zsh
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
     - name: install zsh

--- a/ansible/maintenance/maint-diskspace.yaml
+++ b/ansible/maintenance/maint-diskspace.yaml
@@ -1,6 +1,6 @@
 ---
 - name: check disk space
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   tasks:
     - name: get disk usage
       ansible.builtin.command: df -h

--- a/ansible/maintenance/maint-docker-clean.yaml
+++ b/ansible/maintenance/maint-docker-clean.yaml
@@ -1,6 +1,6 @@
 ---
 - name: clean docker
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   tasks:
     - name: prune non-dangling images
       community.docker.docker_prune:

--- a/ansible/maintenance/maint-reboot-required.yaml
+++ b/ansible/maintenance/maint-reboot-required.yaml
@@ -1,6 +1,6 @@
 ---
 - name: check if system reboot is required
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
     - name: check if system reboot is required

--- a/ansible/maintenance/maint-reboot.yaml
+++ b/ansible/maintenance/maint-reboot.yaml
@@ -1,6 +1,6 @@
 ---
 - name: reboot machine
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
   become: yes
   tasks:
   - name: reboot machine

--- a/ansible/notification/notify-discord.yaml
+++ b/ansible/notification/notify-discord.yaml
@@ -11,7 +11,7 @@
 
 - name: notify discord
 
-  hosts: "{{ hosts }}"
+  hosts: "{{ my_hosts | d([]) }}"
 
   vars:
     # The name that will be shown as sender of the notification. Note


### PR DESCRIPTION
Ensure that the `hosts` definition is always defined, defaulting to an empty set. Due to the lack of an Ansible inventory file this is most likely meant to be set as an Ansible extra variable [1].

We also rename the variable named `hosts` to `my_hosts` because `hosts` is a reserved name in Ansible. Reserved names in Ansible are for example all class variable names of plays, roles, blocks, and tasks [2], and
`hosts` for example is used by plays [3].

[1] https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#defining-variables-at-runtime
[2] https://github.com/ansible/ansible/blob/v2.16.4/lib/ansible/vars/reserved.py#L39
[3] https://github.com/ansible/ansible/blob/v2.16.4/lib/ansible/playbook/play.py#L58

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will help the moderators review your PR. -->

- [x] My pull request has a descriptive title. (unlike `Update index.md`). Check [this](https://www.conventionalcommits.org/en/v1.0.0/) guide regarding titles.
- [x] If applicable, I have tested these changes.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- You can add additional description of changes below this line -->
