### PR TITLE
chore(deps): update docker.io/library/nginx docker tag to 1.26.0-alpine

### DIFF
--- a/docker-compose/nginx/docker-compose.yaml
+++ b/docker-compose/nginx/docker-compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   nginx:
-    image: nginx:1.25.5-alpine
+    image: docker.io/library/nginx:1.26.0-alpine
     container_name: nginx
     ports:
       - 80:80


### PR DESCRIPTION
### Pull Request

Latest version of Nginx is 1.26.0.

---
