### PR TITLE
Rework renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,8 @@
   "labels": ["renovate"],
   "packageRules": [
     {
-      "depTypeList": [ "devDependencies", "require-dev" ],
-      "updateTypes": [ "patch", "minor", "digest"],
+      "matchDepTypes": [ "devDependencies", "require-dev" ],
+      "matchUpdateTypes": [ "patch", "minor", "digest"],
       "groupName": "devDependencies (non-major)"
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,28 @@
- {
+{
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "labels": ["renovate"],
-  "packageRules": [
-    {
-      "matchDepTypes": [ "devDependencies", "require-dev" ],
-      "matchUpdateTypes": [ "patch", "minor", "digest"],
-      "groupName": "devDependencies (non-major)"
-    }
-  ],
   "extends": [
     "config:base",
-    ":preserveSemverRanges",
     ":dependencyDashboard",
-    ":rebaseStalePrs",
     ":enableVulnerabilityAlertsWithLabel('security')",
+    ":preserveSemverRanges",
+    ":rebaseStalePrs",
     "group:recommended"
+  ],
+  "labels": [
+    "renovate"
+  ],
+  "packageRules": [
+    {
+      "groupName": "devDependencies (non-major)",
+      "matchDepTypes": [
+        "devDependencies",
+        "require-dev"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "minor",
+        "patch"
+      ]
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,20 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "enabled": false,
+      "managers": [
+        "docker-compose",
+        "dockerfile"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "packagePatterns": [
+        "^([^/]+\\/)*(mariadb|mysql)(:.*)?$"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Pull Request

Clean up `renovate.json` a bit by fixing indentation and remove deprecations. Also add exceptions for Docker/Docker Compose-based MariaDB and MySQL version tracking in order to ignore major and minor version bumps (i.e., track patchlevel only) as it might break compatibility with applications using them.

---
