### PR TITLE
chore(deps): do not use the `latest` tag for mariadb

### DIFF
--- a/docker-compose/mariadb/docker-compose.yaml
+++ b/docker-compose/mariadb/docker-compose.yaml
@@ -8,7 +8,7 @@ volumes:
 services:
   mariadb:
     # (Recommended) replace "latest" with specific version
-    image: docker.io/library/mariadb:latest
+    image: docker.io/library/mariadb:10.10.6
     # (Optional) remove this section when you don't want to expose
     ports:
       - 3306:3306


### PR DESCRIPTION
Deliberately we do not set the most recent release version here in order to test the Renovate changes done in #247.

---
