### PR TITLE
fix: fully upgrade standalone MariaDB Docker Compose by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,24 @@
       "packagePatterns": [
         "^([^/]+\\/)*(mariadb|mysql)(:.*)?$"
       ]
+    },
+    {
+      "enabled": true,
+      "managers": [
+        "docker-compose",
+        "dockerfile"
+      ],
+      "matchFileNames": [
+        "docker-compose/mariadb/**"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "packagePatterns": [
+        "^([^/]+\\/)*mariadb(:.*)?$"
+      ]
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
Do not apply the restrictions regarding major and minor version bumps to the standalone MariaDB Docker Compose which does not have to respect compatibility to a specific application.

---
