### PR TITLE
fix: attempt to fix Heimdall version tracking by Renovate

### DIFF
--- a/docker-compose/heimdall/docker-compose.yaml
+++ b/docker-compose/heimdall/docker-compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   heimdall:
-    image: lscr.io/linuxserver/heimdall:2021.11.28
+    image: lscr.io/linuxserver/heimdall:2.6.0
     container_name: heimdall
     environment:
       - PUID=1000

--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,16 @@
       "packagePatterns": [
         "^([^/]+\\/)*mariadb(:.+)?$"
       ]
+    },
+    {
+      "managers": [
+        "docker-compose",
+        "dockerfile"
+      ],
+      "packagePatterns": [
+        "^([^/]+\\/)*heimdall(:.+)?$"
+      ],
+      "versioning": "regex:^(?<major>(?!2021)\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
Alas over time the versioning schema of image tags by `lscr.io/linuxserver/heimdall` changed several times, ranging from simply incrementing a counter to a ISO 8601 date-alike variant to finally something which comes close the semantic versioning.

With the default rule set, Renovate gets fooled by the ISO 8601 date variant which was used in year 2021. The idea is to use a regular expression for better matching which kicks out 2021 using a negative lookahead and also require a minor version number in order not to get caught by the counter-like increments.

As a test, the image tag is intentionally set to `2.6.0` while `2.6.1` would be the latest release. This is just to verify whether Renovate does to right thing now.

---
