### PR TITLE
fix: avoid using negative lookaheads which Renovate doesn't understand

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,7 +64,7 @@
       "packagePatterns": [
         "^([^/]+\\/)*heimdall(:.+)?$"
       ],
-      "versioning": "regex:^(?<major>(?!2021)\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
+      "versioning": "regex:^(?<major>\\d{1,2})\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
Fixes #261 

---
