### PR TITLE
Update Prometheus compose templates, add helm and kubernetes templates

### DIFF
--- a/docker-compose/prometheus/docker-compose.yaml
+++ b/docker-compose/prometheus/docker-compose.yaml
@@ -10,6 +10,6 @@ services:
       - 9090:9090
     command: "--config.file=/etc/prometheus/prometheus.yaml"
     volumes:
-      - ./config/prometheus.yaml:/etc/prometheus/prometheus.yaml:ro
+      - /etc/prometheus/prometheus.yaml:/etc/prometheus/prometheus.yaml:ro
       - prometheus-data:/prometheus
     restart: unless-stopped


### PR DESCRIPTION
### Pull Request

Hello, in Server Monitoring // Prometheus and Grafana Tutorial (Sep 21, 2021) Christian prescribes creating the /etc/prometheus directory to store the prometheus.yaml config file.

As of today, the boilerplate repository specifies the prometheus.yaml bind mount source path as ./config/prometheus.yaml

I feel this introduces two problems as config/prometheus.yaml is now incongruent with the guide and using ./ (relative path) gave me issues too. Using / (absolute path) seems like the more reliable option.

If the repo team would like to keep /config/prometheus.ymal or etc/prometheus/config/prometheus.yaml, I can go in that direction and include a read.me for future users.

---
