### PR TITLE
fix: track Nginx stable releases only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,17 @@
         "^([^/]+\\/)*heimdall(:.+)?$"
       ],
       "versioning": "regex:^(?<major>\\d{1,2})\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?$"
+    },
+    {
+      "description": "Nginx container images, track stable releases only",
+      "managers": [
+        "docker-compose",
+        "dockerfile"
+      ],
+      "packagePatterns": [
+        "^([^/]+\\/)*nginx(:.+)?$"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\d*[02468])(\\.(?<patch>\\d+))?(?:-(?<compatibility>.*))?$"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
### Pull Request

For Nginx container images, track stable releases only (i.e., the minor number is even).

---
