### PR TITLE
fix: fix missing double-escaping of backslash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -89,7 +89,7 @@
       "packagePatterns": [
         "^([^/]+\\/)*nginx(:.+)?$"
       ],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\d*[02468])(\\.(?<patch>\\d+))?(?:-(?<compatibility>.*))?$"
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d*[02468])(\\.(?<patch>\\d+))?(?:-(?<compatibility>.*))?$"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
### Pull Request

Forgot to double-escape a backslash in `renovate.json`.

---
