### PR TITLE
Replace `/var/run` by `/run`

### DIFF
--- a/ansible/deployment/portainer/deploy-portainer.yaml
+++ b/ansible/deployment/portainer/deploy-portainer.yaml
@@ -16,6 +16,6 @@
         ports:
           - "9443:9443"
         volumes:
-          - /var/run/docker.sock:/var/run/docker.sock
+          - /run/docker.sock:/var/run/docker.sock
           - portainer-data:/data
         restart_policy: unless-stopped

--- a/ansible/deployment/traefik/deploy-traefik.yaml
+++ b/ansible/deployment/traefik/deploy-traefik.yaml
@@ -11,7 +11,7 @@
           - "80:80"
           - "443:443"
         volumes:
-          - /var/run/docker.sock:/var/run/docker.sock
+          - /run/docker.sock:/run/docker.sock
           - /etc/traefik:/etc/traefik
         restart_policy: unless-stopped
       become: true

--- a/ansible/maintenance/maint-reboot-required.yaml
+++ b/ansible/maintenance/maint-reboot-required.yaml
@@ -7,7 +7,7 @@
     - name: Check if system reboot is required
       become: true
       ansible.builtin.stat:
-        path: /var/run/reboot-required
+        path: /run/reboot-required
       register: reboot_required
 
     - name: Report if reboot is required

--- a/docker-compose/authentik/docker-compose.yaml
+++ b/docker-compose/authentik/docker-compose.yaml
@@ -94,7 +94,7 @@ services:
     # user: root
     volumes:
       # (Optional)  When using the docker socket integration
-      # - /var/run/docker.sock:/var/run/docker.sock
+      # - /run/docker.sock:/run/docker.sock
       - ./media:/media
       - ./certs:/certs
       - ./custom-templates:/templates

--- a/docker-compose/cadvisor/docker-compose.yaml
+++ b/docker-compose/cadvisor/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       - 8080:8080
     volumes:
       - /:/rootfs:ro
-      - /var/run:/var/run:ro
+      - /run:/run:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
       - /dev/disk/:/dev/disk:ro

--- a/docker-compose/factory/runner-pool/docker-compose.yaml
+++ b/docker-compose/factory/runner-pool/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     image: refactr/runner-pool:v0.146.0
     user: root
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /run/docker.sock:/run/docker.sock
       - ./config.json:/etc/runner-agent.json
     # stdin_open: true
     # tty: true

--- a/docker-compose/homepage/docker-compose.yaml
+++ b/docker-compose/homepage/docker-compose.yaml
@@ -29,5 +29,5 @@ services:
   #   ports:
   #     - 127.0.0.1:2375:2375
   #   volumes:
-  #     - /var/run/docker.sock:/var/run/docker.sock:ro # Mounted as read-only
+  #     - /run/docker.sock:/run/docker.sock:ro # Mounted as read-only
   #   restart: unless-stopped

--- a/docker-compose/portainer-agent/docker-compose.yaml
+++ b/docker-compose/portainer-agent/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       - 9001:9001
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes:/var/lib/docker/volumes
     networks:
       - portainer-agent_default

--- a/docker-compose/portainer/docker-compose.yaml
+++ b/docker-compose/portainer/docker-compose.yaml
@@ -11,6 +11,6 @@ services:
       - 9443:9443
       - 8000:8000
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /run/docker.sock:/var/run/docker.sock
       - portainer-data:/data
     restart: unless-stopped

--- a/docker-compose/traefik/docker-compose.yaml
+++ b/docker-compose/traefik/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       # -- (Optional) Enable Dashboard, don't do in production
       # - 8080:8080
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /run/docker.sock:/run/docker.sock:ro
       - ./config/traefik.yaml:/etc/traefik/traefik.yaml:ro
       - ./config/conf/:/etc/traefik/conf/
       - ./config/certs/:/etc/traefik/certs/


### PR DESCRIPTION
### Pull Request

The use of `/var/run` was deprecated by FHS 3.0 nine years ago, so it's time to finally get rid of it where possible. The canonical directory for run-time variable data is `/run` nowadaya,s with `/var/run` just being a symbolic link for backward compatibilty and to ease transition.

---
