### PR TITLE
chore(deps): ignore docker.io/semaphoreui/semaphore docker tag v2.19.10

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -90,6 +90,17 @@
         "^([^/]+\\/)*nginx(:.+)?$"
       ],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d*[02468])(\\.(?<patch>\\d+))?(?:-(?<compatibility>.*))?$"
+    },
+    {
+      "description": "Semaphore container images, ignore erroneous version tags",
+      "managers": [
+        "docker-compose",
+        "dockerfile"
+      ],
+      "packagePatterns": [
+        "^([^/]+\\/)*semaphore(:.+)?$"
+      ],
+      "allowedVersions": "!/^2\\.19\\.10$/"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
### Pull Request

It looks like Semaphore was tagged with an erroneous container image tag which should have rather read `v2.10.10` instead of `v2.19.10`. As this messes up version tracking and makes Renovate miss younger releases we ignore `v2.19.10`.

---
