### PR TITLE
fix: adjust Renovate ignore rule regarding Semaphore 2.19.10

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -100,7 +100,7 @@
       "packagePatterns": [
         "^([^/]+\\/)*semaphore(:.+)?$"
       ],
-      "allowedVersions": "!/^2\\.19\\.10$/"
+      "allowedVersions": "!/^v?2\\.19\\.10$/"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
### Pull Request

Adjust Renovate ignore rule regarding Semaphore `2.19.10`. 

Relates to #338.

---
