### PR TITLE
Create ansible-playbook.yaml

### DIFF
--- a/kestra/ansible-playbook.yaml
+++ b/kestra/ansible-playbook.yaml
@@ -17,8 +17,8 @@ tasks:
           # Files are to be uploaded to the kestra data directory for the namespace in
           # <docker volume for kestra-data>/<namespace>/_files/
           include:
-          - inventory.ini
-          - myplaybook.yaml
+            - inventory.ini
+            - myplaybook.yaml
         type: io.kestra.plugin.ansible.cli.AnsibleCLI
         docker:
           image: cytopia/ansible:latest-tools

--- a/kestra/ansible-playbook.yaml
+++ b/kestra/ansible-playbook.yaml
@@ -1,0 +1,30 @@
+---
+# Kestra ansible-playbook Template
+# ---
+#
+# Run an ansible playbook which has been uploaded to the server.
+#
+id: ansible_job
+namespace: # your-namespace
+
+tasks:
+  - id: ansible
+    type: io.kestra.plugin.core.flow.WorkingDirectory
+    tasks:
+      - id: ansible_task
+        namespaceFiles:
+          enabled: true
+          # Files are to be uploaded to the kestra data directory for the namespace in
+          # <docker volume for kestra-data>/<namespace>/_files/
+          include:
+          - inventory.ini
+          - myplaybook.yaml
+        type: io.kestra.plugin.ansible.cli.AnsibleCLI
+        docker:
+          image: cytopia/ansible:latest-tools
+        env:
+          "ANSIBLE_HOST_KEY_CHECKING": "false"
+        commands:
+        # Apk command only required if use ssh passwords.
+          - apk add sshpass   
+          - ansible-playbook -i inventory.ini myplaybook.yml

--- a/kestra/ansible-playbook.yaml
+++ b/kestra/ansible-playbook.yaml
@@ -25,6 +25,6 @@ tasks:
         env:
           "ANSIBLE_HOST_KEY_CHECKING": "false"
         commands:
-        # Apk command only required if use ssh passwords.
-          - apk add sshpass   
-          - ansible-playbook -i inventory.ini myplaybook.yml
+          # Apk command only required if use ssh passwords.
+          - apk add sshpass
+          - ansible-playbook -i inventory.ini myplaybook.yaml

--- a/kestra/ansible/playbook-inline.yaml
+++ b/kestra/ansible/playbook-inline.yaml
@@ -1,0 +1,42 @@
+---
+# Kestra ansible-playbook Template
+# ---
+#
+# Run an ansible playbook defined inline the kestra flow.
+#
+id: ansible_job
+namespace: # your-namespace
+
+tasks:
+  - id: ansible
+    type: io.kestra.plugin.core.flow.WorkingDirectory
+    tasks:
+      - id: local_files
+        type: io.kestra.core.tasks.storages.LocalFiles
+        inputs:
+          inventory.ini: |
+            srv-demo-1.home.clcreative.de
+          # --> replace with your playbook
+          myplaybook.yml: |
+            ---
+            - hosts: srv-demo-1.home.clcreative.de
+              tasks:
+              - name: upgrade apt packages
+                become: true
+                apt:
+                  upgrade: yes
+                  update_cache: yes
+          # <--
+          id_rsa: "{{ secret('SSH_KEY') }}"
+      - id: ansible_task
+        type: io.kestra.plugin.ansible.cli.AnsibleCLI
+        docker:
+          image: cytopia/ansible:latest-tools
+          user: "1000"  # required to set ssh key permissions
+        env:
+          "ANSIBLE_HOST_KEY_CHECKING": "false"
+          # --> (optional) when using a different remote user
+          # "ANSIBLE_REMOTE_USER": "your-remote-user"
+          # <--
+        commands:
+          - ansible-playbook -i inventory.ini --key-file id_rsa myplaybook.yaml

--- a/kestra/ansible/playbook-password.yaml
+++ b/kestra/ansible/playbook-password.yaml
@@ -14,17 +14,20 @@ tasks:
       - id: ansible_task
         namespaceFiles:
           enabled: true
-          # Files are to be uploaded to the kestra data directory for the namespace in
-          # <docker volume for kestra-data>/<namespace>/_files/
+          # --> upload your files to the kestra data directory for the namespace in
+          #     <docker volume for kestra-data>/<namespace>/_files/
           include:
             - inventory.ini
             - myplaybook.yaml
+          # <--
         type: io.kestra.plugin.ansible.cli.AnsibleCLI
         docker:
           image: cytopia/ansible:latest-tools
         env:
           "ANSIBLE_HOST_KEY_CHECKING": "false"
+          # --> (optional) when using a different remote user
+          # "ANSIBLE_REMOTE_USER": "your-remote-user"
+          # <--
         commands:
-          # Apk command only required if use ssh passwords.
-          - apk add sshpass
+          - apk add sshpass  # only required if use ssh passwords.
           - ansible-playbook -i inventory.ini myplaybook.yaml

--- a/kestra/ansible/playbook-ssh-key.yaml
+++ b/kestra/ansible/playbook-ssh-key.yaml
@@ -1,0 +1,38 @@
+---
+# Kestra ansible-playbook Template
+# ---
+#
+# Run an ansible playbook which has been uploaded to the server, using 
+# ssh key authentication.
+#
+id: ansible_job
+namespace: # your-namespace
+
+tasks:
+  - id: ansible
+    type: io.kestra.plugin.core.flow.WorkingDirectory
+    tasks:
+      - id: load_ssh_key
+        type: io.kestra.core.tasks.storages.LocalFiles
+        inputs:
+          id_rsa: "{{ secret('SSH_KEY') }}"
+      - id: ansible_task
+        namespaceFiles:
+          enabled: true
+          # --> upload your files to the kestra data directory for the namespace in
+          #     <docker volume for kestra-data>/<namespace>/_files/
+          include:
+            - inventory.ini
+            - myplaybook.yaml
+          # <--
+        type: io.kestra.plugin.ansible.cli.AnsibleCLI
+        docker:
+          image: cytopia/ansible:latest-tools
+          user: "1000"  # required to set ssh key permissions
+        env:
+          "ANSIBLE_HOST_KEY_CHECKING": "false"
+          # --> (optional) when using a different remote user
+          # "ANSIBLE_REMOTE_USER": "your-remote-user"
+          # <--
+        commands:
+          - ansible-playbook -i inventory.ini --key-file id_rsa myplaybook.yaml


### PR DESCRIPTION
Adding running ansible playbooks directly from Kestra. Working on Kestra V0.17.9

### Pull Request

*Please write all text in English in order to facilitate communication and collaboration. Thank you!*

---
Hi, Love your channel. 

This is a boilerplate for kestra that I use to run Ansible playbooks. The files do need to be in the kestra data volume (directory is referenced in the template).

Hope this helps.

Tim