### PR TITLE
chore(deps): update docker.io/library/nextcloud docker tag to v30 (#96)

### DIFF
--- a/docker-compose/nextcloud/compose.yaml
+++ b/docker-compose/nextcloud/compose.yaml
@@ -4,7 +4,7 @@ volumes:
   nextcloud-db:
 services:
   nextcloud-app:
-    image: docker.io/library/nextcloud:29.0.7-apache
+    image: docker.io/library/nextcloud:30.0.0-apache
     container_name: nextcloud-app
     ports:
       - 80:80
@@ -17,9 +17,9 @@ services:
       - MYSQL_HOST=nextcloud-db
     restart: unless-stopped
   nextcloud-db:
-    # See compatibility matrix for Nextcloud 29
-    # https://docs.nextcloud.com/server/29/admin_manual/installation/system_requirements.html
-    image: docker.io/library/mariadb:10.6.19
+    # See compatibility matrix for Nextcloud 30
+    # https://docs.nextcloud.com/server/30/admin_manual/installation/system_requirements.html
+    image: docker.io/library/mariadb:10.11.9
     container_name: nextcloud-db
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     volumes:


### PR DESCRIPTION
* chore(deps): update docker.io/library/nextcloud docker tag to v30

* chore(deps): align recommended version of MariaDB to match Nextcloud 30

