### PR TITLE
chore(deps): update public.ecr.aws/gravitational/teleport-distroless docker tag to v16.4.6

### DIFF
--- a/docker-compose/teleport/compose.yaml
+++ b/docker-compose/teleport/compose.yaml
@@ -5,7 +5,7 @@
 #     external: true
 services:
   teleport:
-    image: public.ecr.aws/gravitational/teleport-distroless:16
+    image: public.ecr.aws/gravitational/teleport-distroless:16.4.6
     container_name: teleport
     ports:
       # -- (Optional) Remove this section, when using Traefik


### PR DESCRIPTION
Update public.ecr.aws/gravitational/teleport-distroless docker tag to v16.4.6
