### PR TITLE
Revert "chore(deps): update ghcr.io/goauthentik/server docker tag to v2024.10.3"

### DIFF
--- a/docker-compose/authentik/compose.yaml
+++ b/docker-compose/authentik/compose.yaml
@@ -31,7 +31,7 @@ services:
       - redis_data:/data
     restart: unless-stopped
   server:
-    image: ghcr.io/goauthentik/server:2024.10.3
+    image: ghcr.io/goauthentik/server:2024.10.2
     container_name: authentik-server
     command: server
     environment:
@@ -65,7 +65,7 @@ services:
       - redis
     restart: unless-stopped
   worker:
-    image: ghcr.io/goauthentik/server:2024.10.3
+    image: ghcr.io/goauthentik/server:2024.10.2
     container_name: authentik-worker
     command: worker
     environment:


### PR DESCRIPTION
Authentik `v2024.10.3` contains a crtical bug and shouldn't be upgraded to, see the *announcements* channel on Authentik's Discord server. A fixed `v2024.10.4` should be released soon.