### PR TITLE
fix: use fully qualified container image name including the registry

### DIFF
--- a/docker-compose/clamav/compose.yaml
+++ b/docker-compose/clamav/compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   clamav:
-    image: clamav/clamav:1.4.1
+    image: docker.io/clamav/clamav:1.4.1
     container_name: clamav
     volumes:
       - ./config/clamd.conf:/etc/clamav/clamd.conf:ro

--- a/docker-compose/dockge/compose.yaml
+++ b/docker-compose/dockge/compose.yaml
@@ -2,7 +2,7 @@
 services:
   dockge:
     container_name: dockge
-    image: louislam/dockge:1.4.2
+    image: docker.io/louislam/dockge:1.4.2
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - dockge-data:/app/data

--- a/docker-compose/wazuh/compose.yaml
+++ b/docker-compose/wazuh/compose.yaml
@@ -1,6 +1,6 @@
 services:
   wazuh.manager:
-    image: wazuh/wazuh-manager:4.9.2
+    image: docker.io/wazuh/wazuh-manager:4.9.2
     container_name: wazuh-prod-1-manager
     hostname: wazuh.manager
     ulimits:
@@ -54,7 +54,7 @@ services:
     restart: unless-stopped
 
   wazuh.indexer:
-    image: wazuh/wazuh-indexer:4.9.2
+    image: docker.io/wazuh/wazuh-indexer:4.9.2
     container_name: wazuh-prod-1-indexer
     hostname: wazuh.indexer
     ports:
@@ -87,7 +87,7 @@ services:
     restart: unless-stopped
 
   wazuh.dashboard:
-    image: wazuh/wazuh-dashboard:4.9.2
+    image: docker.io/wazuh/wazuh-dashboard:4.9.2
     container_name: wazuh-prod-1-dashboard
     hostname: wazuh.dashboard
     # --> (Optional) Remove the port mapping when using traefik
@@ -131,7 +131,7 @@ services:
 
   # --> (Optional) When you need to use an SMTP relay for email notifications, and authentication is required
   # postfix:
-  #   image: mwader/postfix-relay:1.1.39
+  #   image: docker.io/mwader/postfix-relay:1.1.39
   #   environment:
   #     - POSTFIX_myhostname=postfix
   #   volumes:


### PR DESCRIPTION
Use fully qualified container image name including the registry.