### PR TITLE
fix: adjust list of Docker packages to be installed

### DIFF
--- a/ansible/docker/inst-docker-ubuntu.yaml
+++ b/ansible/docker/inst-docker-ubuntu.yaml
@@ -30,9 +30,6 @@
       ansible.builtin.apt:
         name:
           - docker-ce
-          - docker-ce-cli
-          - containerd.io
           - docker-buildx-plugin
-          - docker-scan-plugin
           - docker-compose-plugin
         update_cache: true


### PR DESCRIPTION
Don't try to install the obsolete `docker-scan-plugin` package and avoid being overly explicit by requesting transitive dependencies which get installed implicitly anyway.

Fixes #578.