### PR TITLE
fix: don't let Renovate get stuck on a misleading compatibility hint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,17 @@
       ]
     },
     {
+      "description": "Do not match Canonical's Ubuntu version suffix as a compatibility hint",
+      "matchManagers": [
+        "docker-compose",
+        "dockerfile"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?(?:-\\d+(?:\\.\\d+)+_edge)?$",
+      "matchPackageNames": [
+        "/^([^/]+\\/)*ubuntu/bind9(:.+)?$/"
+      ]
+    },
+    {
       "description": "Over time Heimdall changed its versioning schema several times, ensure we only consider the current style",
       "matchManagers": [
         "docker-compose",


### PR DESCRIPTION
Right now Renovate is stuck on `docker.io/ubuntu/bind9:9.18-23.10_edge` and does not detect tag `9.20-24.10_edge` as an update because it tries to stick with `23.10_edge` which gets interpreted as a compatibility hint which doesn't help here at all.