### PR TITLE
Correct Prometeus Compose.yaml

### DIFF
--- a/docker-compose/prometheus/compose.yaml
+++ b/docker-compose/prometheus/compose.yaml
@@ -10,6 +10,6 @@ services:
       - 9090:9090
     command: "--config.file=/etc/prometheus/prometheus.yaml"
     volumes:
-      - ./config/prometheus.yaml:/etc/prometheus/prometheus.yaml:ro
+      - ./config:/etc/prometheus/:ro
       - prometheus-data:/prometheus
     restart: unless-stopped


### PR DESCRIPTION
### Pull Request

Updated the prometheus compose.yaml. The currently the prometheus.yaml volume mapping creates a directory in the container at /etc/prometheus/prometheus.yaml. The command in the compose file for the config sets the location at /etc/prometheus/prometheus.yaml which is  a directory created by the volume mappings.

I removed the prometheus.yaml mapping from both sides of the volume mapping. This makes the config.file command correct and no longer errors with "prometheus.yaml is a directory".

Users need to create the prometheus.yaml config file in the host ./config/ folder.