### PR TITLE
Remove the trailing slash from the host path

### DIFF
--- a/docker-compose/bind9/compose.yaml
+++ b/docker-compose/bind9/compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - "53:53"
     volumes:
-      - /etc/bind/:/etc/bind/
+      - /etc/bind:/etc/bind/
       - /var/cache/bind:/var/cache/bind
       - /var/lib/bind:/var/lib/bind
     restart: unless-stopped


### PR DESCRIPTION
### Pull Request

*Please write all text in English in order to facilitate communication and collaboration. Thank you!*

---

Yes, the first volume mapping:

`- /etc/bind/:/etc/bind/`

has a trailing slash on both the host and container paths.

### Does it matter?

- The trailing slash on the host path (`/etc/bind/`) does not impact functionality in most cases, but it's generally best practice to avoid it for consistency.The trailing slash on the host path (`/etc/bind/`) does not 
-  impact functionality in most cases, but it's generally best practice to avoid it for consistency.
The trailing slash on the container path (`/etc/bind/`) does not matter since it is treated as a directory inside the container.

### Recommended Fix:
Remove the trailing slash from the host path:

`- /etc/bind:/etc/bind/`

This ensures Docker treats /etc/bind as a directory rather than a potential symlink or mount point inconsistency.