### PR TITLE
chore(deps): use fully qualified container image name for Loki

### DIFF
--- a/docker-compose/loki/compose.yaml
+++ b/docker-compose/loki/compose.yaml
@@ -2,7 +2,7 @@
 services:
   loki:
     container_name: loki
-    image: grafana/loki:3.4.2
+    image: docker.io/grafana/loki:3.4.2
     command: "-config.file=/etc/loki/config.yaml"
     ports:
       # --> (Optional) Remove when using traefik...


### PR DESCRIPTION
Use fully qualified container image name for Loki.