### PR TITLE
chore(deps): use fully qualified container image name for Gitlab CE

### DIFF
--- a/docker-compose/gitlab/compose.yaml
+++ b/docker-compose/gitlab/compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   gitlab:
-    image: gitlab/gitlab-ce:17.9.2-ce.0
+    image: docker.io/gitlab/gitlab-ce:17.9.2-ce.0
     container_name: gitlab
     shm_size: '256m'
     environment: {}


### PR DESCRIPTION
Use fully qualified container image name for Gitlab CE.
