### PR TITLE
chore(deps): use fully qualified container image name for Gitlab Runner

### DIFF
--- a/docker-compose/gitlab-runner/compose.yaml
+++ b/docker-compose/gitlab-runner/compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   gitlab-runner:
-    image: gitlab/gitlab-runner:alpine3.19
+    image: docker.io/gitlab/gitlab-runner:alpine-v17.9.1
     container_name: gitlab-runner-1
     volumes:
       - ./config/config.toml:/etc/gitlab-runner/config.toml:ro


### PR DESCRIPTION
Use fully qualified container image name for Gitlab Runner.

While doing so, also switch to a versioned release of Gitlab Runner.