### PR TITLE
chore(deps): update ghcr.io/gethomepage/homepage docker tag to v1

### DIFF
--- a/docker-compose/homepage/compose.yaml
+++ b/docker-compose/homepage/compose.yaml
@@ -1,9 +1,11 @@
 ---
 services:
   homepage:
-    image: ghcr.io/gethomepage/homepage:v0.10.9
+    image: ghcr.io/gethomepage/homepage:v1.0.2
     container_name: homepage
     environment:
+      # (Required) See https://gethomepage.dev/installation/#homepage_allowed_hosts
+      - HOMEPAGE_ALLOWED_HOSTS=${HOMEPAGE_ALLOWED_HOSTS:?HOMEPAGE_ALLOWED_HOSTS not set}
       - LOG_LEVEL=info
     # (Optional) Run as a specific user
     #   - PUID=your-user-id


### PR DESCRIPTION
As of hompage version 1.0 releases, it is required to set the `HOMEPAGE_ALLOWED_HOSTS` variable [1].

[1] https://gethomepage.dev/installation/#homepage_allowed_hosts
