### PR TITLE
chore(deps): update gitea docker tag to v1.24.0

### DIFF
--- a/docker-compose/gitea/compose.yaml
+++ b/docker-compose/gitea/compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   server:
-    image: gitea/gitea:1.23.8
+    image: docker.io/gitea/gitea:1.24.0
     container_name: gitea-server
     environment:
       - USER_UID=1000
@@ -58,7 +58,7 @@ services:
 
 # --> When using internal database
 # db:
-#   image: postgres:14
+#   image: docker.io/library/postgres:17.5
 #   container_name: gitea-db
 #   environment:
 #     - POSTGRES_USER=${POSTGRES_USER:?POSTGRES_USER not set}


### PR DESCRIPTION
### Pull Request

- Upgrade Gitea to `1.24.0`
- Upgrade PostgreSQL to `17.5`
- Use fully-qualified container image names
