### PR TITLE
chore(config): raise Renovate pull request limits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -159,6 +159,8 @@
       "datasourceTemplate": "docker"
     }
   ],
+  "prConcurrentLimit": 30,
+  "prHourlyLimit": 5,
   "separateMinorPatch": true,
   "stopUpdatingLabel": "renovate/stop_updating"
 }


### PR DESCRIPTION
Lately the creation of new PRs is often rate-limited because of existing pending PRs still waiting for reviews. Raising the default limits should mitigate the issue of new PRs not being created, especially security-relevant ones.

- Raise maximum number of parallel pull requests opened by Renovate to `30`
  (setting [`prConcurrentLimit`](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit), default: `10`)
- Raise maximum number of pull requests opened by Renovate per hour to `3`
  (setting [`prHourlyLimit`](https://docs.renovatebot.com/configuration-options/#prhourlylimit), default: `2`)