### PR TITLE
Grafana Alloy hostname environment variable

### DIFF
--- a/docker-compose/alloy/.env.example
+++ b/docker-compose/alloy/.env.example
@@ -1,0 +1,3 @@
+# Alloy container hostname
+# Used in logs & metric labeling
+HOSTNAME=your-server-name-1

--- a/docker-compose/alloy/compose.yaml
+++ b/docker-compose/alloy/compose.yaml
@@ -3,7 +3,7 @@ services:
   alloy:
     image: grafana/alloy:v1.9.2
     container_name: alloy
-    hostname: your-server-name
+    hostname: ${HOSTNAME:-your-server-name}
     command:
       - run
       - --server.http.listen-addr=0.0.0.0:12345


### PR DESCRIPTION
---
Added environment variable to define a hostname of a grafana/alloy container.
@ChristianLempa mentioned that for **_some reason_** it doesn't work.
I can confirm **it works just fine** on my side so I decided to make a PR. Below is my test flow.

Here the variable is set in .env file:
```bash
[host@dev-docker-alchemy-1 alloy]$ cat .env
# Alloy container hostname
# Used in logs & metric labeling
HOSTNAME=test-machine-1
```

Here I get this variable inside the running container:
```bash
[host@dev-docker-alchemy-1 alloy]$ docker exec -it alloy /bin/sh
# hostname
test-machine-1
```

I also added a fallback in case someone forgets to do:
```bash
cp .env.example .env && nano .env
```

Seems just right to me on my Grafana:
<img width="1010" height="228" alt="image" src="https://github.com/user-attachments/assets/66997e9b-9079-46c6-8c51-922924436b88" />
