### PR TITLE
Traefik: Document usecases more for a generic DNS provider

### DIFF
--- a/docker-compose/traefik/compose.yaml
+++ b/docker-compose/traefik/compose.yaml
@@ -14,7 +14,8 @@ services:
       - ./config/:/etc/traefik/:ro
       - ./certs/:/var/traefik/certs/:rw
     environment:
-      - CF_DNS_API_TOKEN=your-cloudflare-api-token  # <-- Change this to your Cloudflare API Token
+      #- LEGO_DISABLE_CNAME_SUPPORT=true # <--- (Optional) Enable if CNAME Wildcard issues. See: https://doc.traefik.io/traefik/getting-started/faq/#why-does-lets-encrypt-wildcard-certificate-renewalgeneration-with-dns-challenge-fail
+      - CF_DNS_API_TOKEN=your-cloudflare-api-token  # <-- Change to your providers env-var and your generated API-key. For Cloudflare, see: https://go-acme.github.io/lego/dns/cloudflare/index.html#credentials
     networks:
       - frontend
     restart: unless-stopped

--- a/docker-compose/traefik/config/example.externalservice.yaml
+++ b/docker-compose/traefik/config/example.externalservice.yaml
@@ -10,7 +10,7 @@
 #         - web
 #         - websecure
 #       tls:
-#         certResolver: cloudflare
+#         certResolver: CertificateResolver0
 #
 #   # -- Change Service Configuration here...
 #   services:

--- a/docker-compose/traefik/config/traefik.yaml
+++ b/docker-compose/traefik/config/traefik.yaml
@@ -35,13 +35,13 @@ entryPoints:
 
 # -- Configure your CertificateResolver here...
 certificatesResolvers:
-  cloudflare:
+  CertificateResolver0:
     acme:
-      email: your-email@example.com  # <-- Change this to your email
-      storage: /var/traefik/certs/cloudflare-acme.json
-      caServer: "https://acme-v02.api.letsencrypt.org/directory"
-      dnsChallenge:
-        provider: cloudflare  # <-- (Optional) Change this to your DNS provider
+      email: your-email@example.com  # <-- Replace with the email where you want to receive Let's Encrypt notices.
+      storage: /var/traefik/certs/acme.json
+      caServer: "https://acme-v02.api.letsencrypt.org/directory" # Use "https://acme-staging-v02.api.letsencrypt.org/directory" when testing.
+      dnsChallenge: # <--- (Optional) See: https://doc.traefik.io/traefik/https/acme/#dnschallenge
+        provider: cloudflare  # <-- Change this to your DNS provider. See: https://doc.traefik.io/traefik/https/acme/#providers
         resolvers:
           - "1.1.1.1:53"
           - "8.8.8.8:53"


### PR DESCRIPTION
### Pull Request

Hi! \
I modified your Traefik boilerplate so it appeals more to a generic DNS-provider. With all the examples being CloudFlare, I thought it might give off the impression that it only works with CloudFlare or that CloudFlare is superior or the easiest to use for Traefik. So I wanted to add comments with additional documentation for the user.

Hopefully these changes makes it easier to use in case you are not using CloudFlare for your domain :)

Also feel free to edit.

---
