### PR TITLE
feat(changelog): Add CHANGELOG.md and automate release notes

### DIFF
--- a/.github/workflows/release-create-cli-release.yaml
+++ b/.github/workflows/release-create-cli-release.yaml
@@ -110,6 +110,24 @@ jobs:
       #     echo "Publishing to PyPI..."
       #     twine upload dist/*
 
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          # Extract the [Unreleased] section from CHANGELOG.md
+          CHANGELOG=$(awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
+          
+          if [ -z "$CHANGELOG" ]; then
+            echo "No changelog entries found for this release"
+            CHANGELOG="See commit history for details."
+          fi
+          
+          # Save to output using heredoc to handle multiline
+          {
+            echo 'content<<EOF'
+            echo "$CHANGELOG"
+            echo EOF
+          } >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -117,6 +135,12 @@ jobs:
           name: Release ${{ steps.version.outputs.tag }}
           body: |
             ## Boilerplates CLI ${{ steps.version.outputs.tag }}
+
+            ${{ steps.changelog.outputs.content }}
+
+            ---
+
+            ### Installation
 
             Install using the installation script:
             ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Improved error handling and display output consistency
+
+### Fixed
+- Repository fetch fails when library directory already exists
+- Install script reliability improvements
+
+## [0.0.4] - 2025-01-XX
+
+Initial public release with core CLI functionality.
+
+[unreleased]: https://github.com/christianlempa/boilerplates/compare/v0.0.4...HEAD
+[0.0.4]: https://github.com/christianlempa/boilerplates/releases/tag/v0.0.4


### PR DESCRIPTION
## Summary

Adds a proper CHANGELOG.md file following Keep a Changelog format and automates the inclusion of changelog content in GitHub releases.

## Changes

- ✅ Add CHANGELOG.md with Keep a Changelog format
- ✅ Populate [Unreleased] section with v0.0.5 changes
- ✅ Update GitHub Action to extract changelog for releases
- ✅ Automatically include changelog content in release notes

## Workflow

1. **During development**: Add changes to [Unreleased] section
2. **On release**: GitHub Action extracts and includes in release notes
3. **After release**: Manually move [Unreleased] to versioned section

## Testing

- [ ] Verify CHANGELOG.md format
- [ ] Test GitHub Action on next release

Fixes #1296