### PR TITLE
fix(alloy): Add rootfs_path configuration to prometheus.exporter.unix

### DIFF
--- a/library/compose/alloy/config/config.alloy.j2
+++ b/library/compose/alloy/config/config.alloy.j2
@@ -145,6 +145,7 @@ discovery.relabel "metrics" {
 prometheus.exporter.unix "metrics" {
   disable_collectors = ["ipvs", "btrfs", "infiniband", "xfs", "zfs"]
   enable_collectors = ["meminfo"]
+  rootfs_path = "/rootfs"
   filesystem {
     fs_types_exclude     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|tmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
     mount_points_exclude = "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+)($|/)"


### PR DESCRIPTION
## Description

This PR fixes a misconfiguration in the Alloy boilerplate where the `prometheus.exporter.unix` component was not properly configured to access the host filesystem.

## Problem

The Docker Compose configuration mounts the host root filesystem at `/:/rootfs:ro`, but the Alloy configuration was using the default `rootfs_path` of `/`, causing it to read metrics from the container's filesystem instead of the host's.

## Solution

Added `rootfs_path = "/rootfs"` to the `prometheus.exporter.unix` component configuration to align with the volume mount path.

## Changes

- Added `rootfs_path = "/rootfs"` to `library/compose/alloy/config/config.alloy.j2` (line 148)

## Impact

After this change:
- Filesystem metrics (especially Used Root FS stat) will report correctly for the host system
- All node_exporter metrics that depend on accessing the host filesystem will work as expected

## Testing

This configuration follows the official Grafana Alloy documentation for the `prometheus.exporter.unix` component.

Closes #1326