### PR TITLE
feat: add flake for nix install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Each template includes sensible defaults, best practices, and common configurati
 
 ### Installation
 
+#### Automated installer script
+
 Install the Boilerplates CLI using the automated installer:
 
 ```bash
@@ -37,10 +39,34 @@ curl -fsSL https://raw.githubusercontent.com/christianlempa/boilerplates/main/sc
 
 The installer uses `pipx` to create an isolated environment for the CLI tool. Once installed, the `boilerplates` command will be available in your terminal.
 
+#### Nixos
+
+If you are using nix flakes
+
+```bash
+# Run without installing
+nix run github:christianlempa/boilerplates -- --help
+
+# Install to your profile
+nix profile install github:christianlempa/boilerplates
+
+# Or directly in your flake
+{
+  inputs.boilerplates.url = "github:christianlempa/boilerplates";
+
+  outputs = { self, nixpkgs, boilerplates }: {
+    # Use boilerplates.packages.${system}.default
+  };
+}
+
+# Use in a temporary shell
+nix shell github:christianlempa/boilerplates
+```
+
 ### Quick Start
 
 ```bash
-# Explore 
+# Explore
 boilerplates --help
 
 # Update Repository Library

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1760878510,
+        "narHash": "sha256-K5Osef2qexezUfs0alLvZ7nQFTGS9DL2oTVsIXsqLgs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5e2a59a5b1a82f89f2c7e598302a9cacebb72a67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "A curated collection of production-ready templates for your homelab and infrastructure projects";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        boilerplates = pkgs.python3Packages.buildPythonApplication {
+          pname = "boilerplates";
+          version = "0.0.6";
+
+          src = ./.;
+
+          format = "pyproject";
+
+          nativeBuildInputs = with pkgs.python3Packages; [
+            setuptools
+            wheel
+          ];
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+            typer
+            rich
+            pyyaml
+            python-frontmatter
+            jinja2
+          ];
+
+          meta = with pkgs.lib; {
+            description = "A CLI for managing boilerplates and templates";
+            homepage = "https://github.com/christianlempa/boilerplates";
+            license = licenses.mit;
+            maintainers = ["Théo Posty <theo+github@posty.fr>"];
+            mainProgram = "boilerplates";
+          };
+        };
+      in {
+        packages = {
+          default = boilerplates;
+          boilerplates = boilerplates;
+        };
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${boilerplates}/bin/boilerplates";
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
### Pull Request

*Please write all text in English in order to facilitate communication and collaboration. Thank you!*

---

# Add NixOS installation support

This PR adds NixOS installation support to make it easier for NixOS users to install and use the boilerplates.

NixOS uses a declarative package management system, and this addition allows users to install the package directly through their system configuration rather than using traditional installation methods (which is not easy to use because of the python dependencies).

## Changes
- Added Nix package definition/flake for NixOS compatibility
- Added documentation in the README

This should streamline the installation process for the NixOS community.