### PR TITLE
feat(compose): update traefik template from release/v0.1.0

### DIFF
--- a/library/compose/traefik/compose.yaml.j2
+++ b/library/compose/traefik/compose.yaml.j2
@@ -1,17 +1,18 @@
 services:
   {{ service_name }}:
-    image: docker.io/library/traefik:v3.5.4
+    image: docker.io/library/traefik:v3.5.3
     {% if not swarm_enabled %}
     container_name: {{ container_name }}
+    security_opt:
+      - no-new-privileges:true
     {% endif %}
-    {% if ports_enabled %}
+    hostname: {{ container_hostname }}
     ports:
-      - "80:80"
-      - "443:443"
-      {% if traefik_dashboard_enabled %}
-      - "8080:8080"  # Dashboard (don't use in production)
+      - "{{ ports_http }}:80"
+      - "{{ ports_https }}:443"
+      {% if dashboard_enabled %}
+      - "{{ ports_dashboard }}:8080"
       {% endif %}
-    {% endif %}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       {% if not swarm_enabled %}
@@ -26,23 +27,21 @@ services:
       - traefik_certs:/var/traefik/certs/:rw
       {% endif %}
       {% endif %}
-      {% if traefik_tls_enabled %}
-      {% if not swarm_enabled %}
+      {% if traefik_tls_enabled and not swarm_enabled %}
       - ./.env.secret:/.env.secret:ro
       {% endif %}
     env_file:
       - ./.env
-    {% endif %}
     {% if swarm_enabled %}
     configs:
       - source: traefik_config
         target: /etc/traefik/traefik.yaml
       - source: traefik_middlewares
         target: /etc/traefik/files/middlewares.yaml
-      - source: traefik_tls
-        target: /etc/traefik/files/tls.yaml
-      - source: traefik_external_services
-        target: /etc/traefik/files/external-services.yaml
+      - source: traefik_routers
+        target: /etc/traefik/files/routers.yaml
+      - source: traefik_services
+        target: /etc/traefik/files/services.yaml
     {% endif %}
     environment:
       - TZ={{ container_timezone }}
@@ -52,10 +51,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
-    {% if network_enabled %}
     networks:
-      - {{ network_name }}
-    {% endif %}
+      - {{ traefik_network }}
     {% if swarm_enabled %}
     {% if traefik_tls_enabled %}
     secrets:
@@ -85,7 +82,7 @@ volumes:
     driver: local
     driver_opts:
       type: nfs
-      o: addr={{ swarm_volume_nfs_server }},{{ swarm_volume_nfs_options }}
+      o: addr={{ swarm_volume_nfs_server }},nfsvers=4,{{ swarm_volume_nfs_options }}
       device: ":{{ swarm_volume_nfs_path }}"
     {% endif %}
 {% endif %}
@@ -95,10 +92,10 @@ configs:
     file: ./config/traefik.yaml
   traefik_middlewares:
     file: ./config/files/middlewares.yaml
-  traefik_tls:
-    file: ./config/files/tls.yaml
-  traefik_external_services:
-    file: ./config/files/external-services.yaml
+  traefik_routers:
+    file: ./config/files/routers.yaml
+  traefik_services:
+    file: ./config/files/services.yaml
 
 {% if traefik_tls_enabled %}
 secrets:
@@ -107,10 +104,9 @@ secrets:
 {% endif %}
 {% endif %}
 
-{% if network_enabled %}
 networks:
-  {{ network_name }}:
-    {% if network_external %}
+  {{ traefik_network }}:
+    {% if traefik_network_external %}
     external: true
     {% else %}
     {% if swarm_enabled %}
@@ -119,6 +115,5 @@ networks:
     {% else %}
     driver: bridge
     {% endif %}
-    name: {{ network_name }}
+    name: {{ traefik_network }}
     {% endif %}
-{% endif %}

--- a/library/compose/traefik/config/files/middlewares.yaml.j2
+++ b/library/compose/traefik/config/files/middlewares.yaml.j2
@@ -2,11 +2,27 @@
 # Traefik Dynamic Middleware Configuration
 # This file is watched by Traefik and changes are applied automatically
 
+{% if security_enabled or authentik_enabled -%}
 http:
   middlewares:
-{% if authentik_enabled %}
+{% if security_enabled -%}
+    # Production-Ready Security Headers Middleware
+    # Use in service labels: traefik.http.routers.myservice.middlewares={{ traefik_security_middleware_name }}@file
+    {{ traefik_security_middleware_name }}:
+      headers:
+        frameDeny: true
+        browserXssFilter: true
+        contentTypeNosniff: true
+        sslRedirect: true
+        forceSTSHeader: true
+        stsSeconds: 31536000
+        stsIncludeSubdomains: true
+        stsPreload: true
+
+{% endif -%}
+{% if authentik_enabled -%}
     # Authentik Forward Auth Middleware
-    # Use this middleware in your service labels: traefik.http.routers.myservice.middlewares={{ traefik_authentik_middleware_name }}@file
+    # Use in service labels: traefik.http.routers.myservice.middlewares={{ traefik_authentik_middleware_name }}@file
     {{ traefik_authentik_middleware_name }}:
       forwardAuth:
         address: {{ authentik_outpost_url }}/outpost.goauthentik.io/auth/traefik
@@ -24,43 +40,16 @@ http:
           - X-authentik-meta-app
           - X-authentik-meta-version
 
-{% endif %}
-    # Example: Custom Headers Middleware
-    # Uncomment and customize as needed
-    # custom-headers:
-    #   headers:
-    #     customRequestHeaders:
-    #       X-Custom-Header: "value"
-    #     customResponseHeaders:
-    #       X-Custom-Response: "value"
-
-    # Example: Rate Limiting Middleware
-    # Uncomment and customize as needed
-    # rate-limit:
-    #   rateLimit:
-    #     average: 100
-    #     burst: 50
-    #     period: 1s
-
-    # Example: IP Whitelist Middleware
-    # Uncomment and customize as needed
-    # ip-whitelist:
-    #   ipWhiteList:
-    #     sourceRange:
-    #       - "192.168.1.0/24"
-    #       - "10.0.0.0/8"
-
-    # Example: Basic Auth Middleware
-    # Uncomment and customize as needed
-    # Generate passwords with: htpasswd -nb user password
-    # basic-auth:
-    #   basicAuth:
-    #     users:
-    #       - "admin:$apr1$..."
-
-    # Example: Redirect Scheme Middleware
-    # Uncomment and customize as needed
-    # redirect-to-https:
-    #   redirectScheme:
-    #     scheme: https
-    #     permanent: true
+{% endif -%}
+{% else -%}
+# No middlewares configured
+# Uncomment the example below to add custom middlewares:
+#
+# http:
+#   middlewares:
+#     # Example: Rate limiting
+#     rate-limit:
+#       rateLimit:
+#         average: 100
+#         burst: 50
+{% endif -%}

--- a/library/compose/traefik/config/files/routers.yaml
+++ b/library/compose/traefik/config/files/routers.yaml
@@ -1,0 +1,27 @@
+---
+# Traefik Dynamic Router Configuration
+# Define routers to route traffic to services
+# Uncomment and customize the examples below
+
+# http:
+#   routers:
+#     # Example 1: Simple host-based routing with HTTPS
+#     my-app:
+#       rule: "Host(`app.example.com`)"
+#       service: my-app-service
+#       entryPoints:
+#         - websecure
+#       tls:
+#         certResolver: cloudflare
+#
+#     # Example 2: Path-based routing with middleware
+#     api:
+#       rule: "Host(`example.com`) && PathPrefix(`/api`)"
+#       service: api-service
+#       priority: 10
+#       entryPoints:
+#         - websecure
+#       tls:
+#         certResolver: cloudflare
+#       middlewares:
+#         - rate-limit@file

--- a/library/compose/traefik/config/files/services.yaml
+++ b/library/compose/traefik/config/files/services.yaml
@@ -1,0 +1,28 @@
+---
+# Traefik Dynamic Service Configuration
+# Define backend services that routers connect to
+# Uncomment and customize the examples below
+
+# http:
+#   services:
+#     # Example 1: Single backend server
+#     my-app-service:
+#       loadBalancer:
+#         servers:
+#           - url: "http://192.168.1.100:8080"
+#
+#     # Example 2: Load balanced service with multiple backends
+#     api-service:
+#       loadBalancer:
+#         servers:
+#           - url: "http://192.168.1.10:8080"
+#           - url: "http://192.168.1.11:8080"
+#         sticky:
+#           cookie:
+#             name: api-sticky
+#             httpOnly: true
+#
+# # Server Transport for HTTPS backends with self-signed certificates
+# serversTransports:
+#   insecure:
+#     insecureSkipVerify: true

--- a/library/compose/traefik/config/traefik.yaml.j2
+++ b/library/compose/traefik/config/traefik.yaml.j2
@@ -12,13 +12,29 @@ log:
 accesslog: {}
 {% endif %}
 
-{% if traefik_dashboard_enabled %}
+ping:
+  entryPoint: ping
+
+{% if dashboard_enabled %}
 api:
   dashboard: true
   insecure: true
 {% endif %}
 
+{% if prometheus_enabled %}
+metrics:
+  prometheus:
+    entryPoint: metrics
+    addRoutersLabels: true
+{% endif %}
+
 entryPoints:
+  ping:
+    address: :8082
+  {% if prometheus_enabled %}
+  metrics:
+    address: :9090
+  {% endif %}
   {{ traefik_entrypoint }}:
     address: :80
     {% if traefik_tls_enabled and traefik_tls_redirect %}
@@ -35,28 +51,51 @@ entryPoints:
 
 {% if traefik_tls_enabled %}
 certificatesResolvers:
-  {{ traefik_tls_certresolver | default('cloudflare') }}:
+  {{ traefik_tls_certresolver }}:
     acme:
       email: {{ traefik_tls_acme_email }}
       storage: /var/traefik/certs/acme.json
       caServer: "https://acme-v02.api.letsencrypt.org/directory"
       dnsChallenge:
-        provider: {{ traefik_tls_acme_provider | default('cloudflare') }}
+        provider: {{ traefik_tls_acme_provider }}
         resolvers:
           - 1.1.1.1:53
           - 8.8.8.8:53
+
+tls:
+  options:
+    default:
+      minVersion: {{ traefik_tls_min_version }}
+      {% if traefik_tls_secure_ciphers %}
+      cipherSuites:
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      {% endif %}
 {% endif %}
 
-# NOTE: If using self-signed certificates in your backend services, uncomment the following section
-# to disable certificate verification (not recommended for production use).
-# ---
-# serversTransport:
-#   insecureSkipVerify: true
+{% if traefik_tls_skipverify %}
+http:
+  serversTransports:
+    insecure:
+      insecureSkipVerify: true
+{% endif %}
+
 
 providers:
+  {% if swarm_enabled %}
+  swarm:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+    network: {{ traefik_network }}
+  {% else %}
   docker:
     exposedByDefault: false
-    network: {{ network_name }}
+    network: {{ traefik_network }}
+  {% endif %}
   file:
     directory: /etc/traefik/files
     watch: true

--- a/library/compose/traefik/template.yaml
+++ b/library/compose/traefik/template.yaml
@@ -11,53 +11,21 @@ metadata:
     Project: https://traefik.io/
 
     Documentation: https://doc.traefik.io/traefik/
-  version: v3.5.4
+  version: v3.5.3
   author: "Christian Lempa"
-  date: '2025-10-31'
+  date: "2025-10-02"
   tags:
-    - reverse-proxy
-    - load-balancer
+    - traefik
+    - authentik
+    - swarm
   next_steps: |
-    1. Start Traefik:
+    {% if swarm_enabled %}
+    1. Deploy Traefik to Docker Swarm:
+       docker stack deploy -c docker-compose.yaml traefik
+    {% else %}
+    1. Start Traefik with Docker Compose:
        docker compose up -d
-
-    2. Configure your domain DNS:
-       - Point your domain A/AAAA records to your server IP
-       {% if traefik_tls_enabled -%}
-       - Configure DNS API credentials in .env file
-       - Ensure {{ traefik_tls_acme_provider }} API token has DNS edit permissions
-       {%- endif %}
-
-    3. Access the dashboard:
-       {% if traefik_dashboard_enabled -%}
-       - Dashboard: http://localhost:8080
-       - WARNING: Dashboard is in insecure mode - don't use in production!
-       {%- else -%}
-       - Dashboard is disabled (secure production setup)
-       - Enable it temporarily by setting traefik_dashboard_enabled=true
-       {%- endif %}
-
-    4. Deploy your services:
-       - Ensure services use the '{{ network_name }}' network
-       - Add Traefik labels to your service containers
-       - Services will be automatically discovered and routed
-
-    5. Configuration files:
-       - Static config: config/traefik.yml
-       - Dynamic config: config/conf.d/*.yml
-       {% if traefik_tls_enabled -%}
-       - TLS certificates: certs/acme.json
-       {%- endif %}
-
-    6. Security recommendations:
-       - Disable dashboard in production (traefik_dashboard_enabled=false)
-       - Use TLS/HTTPS for all services
-       - Store API tokens in Docker secrets (Swarm) or secure vaults
-       - Regularly update Traefik to latest version
-       - Review and limit network exposure
-
-    For more information, visit: https://doc.traefik.io/traefik/
-  draft: true
+    {% endif %}
 spec:
   general:
     title: "General"
@@ -67,34 +35,83 @@ spec:
         default: "traefik"
       container_name:
         default: "traefik"
+      container_hostname:
+        default: "traefik"
+  ports:
+    needs: []
+    vars:
+      ports_http:
+        type: "int"
+        description: "HTTP port (external)"
+        default: 80
+        extra: "Maps to entrypoint 'web'"
+      ports_https:
+        type: "int"
+        description: "HTTPS port (external)"
+        default: 443
+        extra: "Maps to entrypoint 'websecure'"
+      ports_dashboard:
+        type: "int"
+        description: "Dashboard port (external)"
+        default: 8080
+        extra: "Only used when dashboard is enabled"
+  traefik:
+    title: "Settings"
+    needs: []
+    vars:
+      traefik_network:
+        type: "str"
+        description: "Traefik network name"
+        default: "traefik"
+        extra: "Network that Traefik uses to connect to services"
+      traefik_network_external:
+        type: "bool"
+        description: "Use existing Docker network (external)"
+        default: false
+      traefik_entrypoint:
+        type: "str"
+        description: "HTTP entrypoint"
+        default: "web"
+      dashboard_enabled:
+        type: "bool"
+        description: "Enable Traefik dashboard"
+        default: false
+        extra: "WARNING: Don't use in production!"
       accesslog_enabled:
         type: "bool"
         description: "Enable Traefik access log"
         default: false
-  traefik:
-    title: "Traefik Settings"
-    description: "Configure Traefik as a reverse proxy"
-    required: true
-    vars:
-      traefik_entrypoint:
-        type: "str"
-        description: "HTTP entrypoint name (non-TLS)"
-        default: "web"
-        extra: "Standard HTTP traffic on port 80"
-      traefik_dashboard_enabled:
+      prometheus_enabled:
         type: "bool"
-        description: "Enable Traefik dashboard (insecure mode)"
+        description: "Enable Prometheus metrics"
         default: false
-        extra: "WARNING: Don't use in production! Exposes dashboard on port 8080"
+      security_enabled:
+        type: "bool"
+        description: "Create production-ready security headers middleware"
+        default: true
+        extra: "Enables HSTS, XSS protection, frame denial, etc."
+      traefik_security_middleware_name:
+        type: "str"
+        description: "Name of the security headers middleware"
+        default: "security-headers"
+        needs: "security_enabled"
+        extra: "Reference in router labels as '{name}@file'"
   traefik_tls:
-    title: "Traefik TLS Settings"
-    description: "Configure TLS/SSL with Let's Encrypt ACME"
-    needs: null
+    title: "TLS Settings"
+    needs: []
     vars:
       traefik_tls_enabled:
         type: "bool"
         description: "Enable HTTPS/TLS with ACME"
         default: false
+      traefik_tls_entrypoint:
+        type: "str"
+        description: "TLS entrypoint"
+        default: "websecure"
+      traefik_tls_certresolver:
+        type: "str"
+        description: "Traefik certificate resolver name"
+        default: "cloudflare"
       traefik_tls_acme_provider:
         type: "enum"
         description: "ACME DNS challenge provider"
@@ -106,12 +123,6 @@ spec:
         type: "str"
         description: "DNS provider API token"
         sensitive: true
-        extra: "For Cloudflare, create an API token with Zone:DNS:Edit permissions. Leave empty to use Docker Swarm secrets."
-      traefik_tls_acme_secret_name:
-        type: "str"
-        description: "Docker Swarm secret name for API token (swarm mode only)"
-        default: "cloudflare_api_token"
-        extra: "The secret name to use in Docker Swarm for storing the API token"
       traefik_tls_acme_email:
         type: "str"
         description: "Email address for ACME (Let's Encrypt) registration"
@@ -121,39 +132,47 @@ spec:
         type: "bool"
         description: "Redirect all HTTP traffic to HTTPS"
         default: true
-  ports:
-    toggle: "ports_enabled"
-    vars:
-      traefik_http_port:
-        type: "int"
-        description: "HTTP port (external)"
-        default: 80
-        extra: "Maps to entrypoint 'web' (port 80)"
-      traefik_https_port:
-        type: "int"
-        description: "HTTPS port (external)"
-        default: 443
-        extra: "Maps to entrypoint 'websecure' (port 443)"
-  network:
-    vars:
-      network_enabled:
+      traefik_tls_min_version:
+        type: "enum"
+        description: "Minimum TLS version"
+        default: "VersionTLS12"
+        options:
+          - "VersionTLS12"
+          - "VersionTLS13"
+        extra: "TLS 1.2 is recommended for compatibility, TLS 1.3 for maximum security"
+      traefik_tls_secure_ciphers:
+        type: "bool"
+        description: "Enable strict cipher suites (recommended)"
         default: true
-      network_mode:
-        default: "bridge"
-      network_name:
-        default: "proxy"
-      network_external:
+        extra: "Enforces modern, secure cipher suites"
+      traefik_tls_skipverify:
+        type: "bool"
+        description: "Skip TLS verification for backend servers"
         default: false
-  authentik:
-    title: Authentik Middleware
-    description: Enable Authentik SSO integration for Traefik
+        extra: "WARNING: Only enable for self-signed certificates in trusted environments"
+  swarm:
+    needs: []
     vars:
+      traefik_tls_acme_secret_name:
+        type: "str"
+        description: "Docker Swarm secret name for API token"
+        default: "cloudflare_api_token"
+  authentik:
+    title: "Authentik Middleware"
+    description: "Enable Authentik SSO integration for Traefik"
+    vars:
+      authentik_enabled:
+        type: "bool"
+        description: "Enable Authentik SSO integration"
+        default: false
       authentik_outpost_url:
         type: "url"
         description: "Authentik outpost URL (e.g., http://authentik-outpost:9000)"
         default: "http://authentik-outpost:9000"
+        needs: "authentik_enabled"
       traefik_authentik_middleware_name:
         type: "str"
         description: "Name of the Authentik middleware"
         default: "authentik"
-        extra: "Reference this in router labels as '{name}@file'"
+        needs: "authentik_enabled"
+        extra: "Reference in router labels as '{name}@file'"


### PR DESCRIPTION
Updates the Traefik compose template from release/v0.1.0 to main branch.

## Changes
- Reorganized template variables and sections
- Added new configuration files (routers.yaml, services.yaml)
- Enhanced TLS/SSL configuration with min version and cipher options
- Added Docker Swarm support
- Added Prometheus metrics and ping endpoints
- Updated security middleware configuration
- Improved network and port configuration flexibility

This brings the improved Traefik template from the release branch to main.