### PR TITLE
fix(alloy): Replace metric_relabel_configs with prometheus.relabel component

### DIFF
--- a/library/compose/alloy/config/config.alloy.j2
+++ b/library/compose/alloy/config/config.alloy.j2
@@ -121,17 +121,21 @@ prometheus.exporter.cadvisor "dockermetrics" {
   storage_duration = "5m"
 }
 
-prometheus.scrape "dockermetrics" {
-  targets    = prometheus.exporter.cadvisor.dockermetrics.targets
+/* Relabel component to drop container_spec metrics that often have NaN values */
+prometheus.relabel "docker_filter" {
   forward_to = [prometheus.remote_write.default.receiver]
-  scrape_interval = "10s"
   
-  // Drop container_spec metrics that often have NaN values for stopped containers
-  metric_relabel_configs {
+  rule {
     source_labels = ["__name__"]
     regex = "container_spec_(cpu_period|cpu_quota|cpu_shares|memory_limit_bytes|memory_swap_limit_bytes|memory_reservation_limit_bytes)"
     action = "drop"
   }
+}
+
+prometheus.scrape "dockermetrics" {
+  targets    = prometheus.exporter.cadvisor.dockermetrics.targets
+  forward_to = [prometheus.relabel.docker_filter.receiver]
+  scrape_interval = "10s"
 }
 {% endif %}
 


### PR DESCRIPTION
## Problem

The Alloy template was using Prometheus syntax (`metric_relabel_configs`) which is incompatible with Alloy's configuration format, causing the service to fail with:
```
Error: "unrecognized block name 'metric_relabel_configs'"
```

## Solution

Replaced the incompatible `metric_relabel_configs` block with a proper `prometheus.relabel` component that:
- Uses Alloy's `rule` block syntax
- Drops `container_spec_*` metrics that cause NaN values for stopped containers
- Creates correct pipeline: `prometheus.scrape` → `prometheus.relabel` → `prometheus.remote_write`

## Changes

- Created new `prometheus.relabel "docker_filter"` component
- Updated `prometheus.scrape "dockermetrics"` to forward to relabel receiver
- Maintains same filtering logic for problematic metrics

## Testing

Tested in production environment:
- srv-prod-1: alloy.service active (running)
- srv-prod-2: alloy.service active (running)
- systemd no longer degraded

Closes #1506