### PR TITLE
fix(compose): correct Cloudflare API token environment variable name

### DIFF
--- a/library/compose/traefik/.env.j2
+++ b/library/compose/traefik/.env.j2
@@ -1,5 +1,5 @@
 # Traefik Environment Variables
 # Reference to secret file containing API token
 {% if traefik_tls_enabled and traefik_tls_acme_provider == "cloudflare" %}
-CF_API_TOKEN_FILE=/.env.secret
+CF_DNS_API_TOKEN_FILE=/.env.secret
 {% endif %}

--- a/library/compose/traefik/compose.yaml.j2
+++ b/library/compose/traefik/compose.yaml.j2
@@ -46,7 +46,11 @@ services:
     environment:
       - TZ={{ container_timezone }}
       {% if traefik_tls_enabled and traefik_tls_acme_provider == 'cloudflare' %}
-      - CF_API_TOKEN_FILE=/.env.secret
+      {% if swarm_enabled %}
+      - CF_DNS_API_TOKEN_FILE=/run/secrets/{{ traefik_tls_acme_secret_name }}
+      {% else %}
+      - CF_DNS_API_TOKEN_FILE=/.env.secret
+      {% endif %}
       {% endif %}
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
@@ -59,9 +63,7 @@ services:
     {% if swarm_enabled %}
     {% if traefik_tls_enabled %}
     secrets:
-      - source: {{ traefik_tls_acme_secret_name }}
-        target: /.env.secret
-        mode: 0400
+      - {{ traefik_tls_acme_secret_name }}
     {% endif %}
     deploy:
       mode: {{ swarm_placement_mode }}


### PR DESCRIPTION
## Changes

Fixes incorrect Cloudflare environment variable names in Traefik boilerplate.

### Before
- `CF_API_TOKEN_FILE` (incorrect)

### After  
- `CF_DNS_API_TOKEN_FILE` (correct)

### Additional Improvements
- Fixed swarm mode to use native secrets instead of target mount
- Properly handles both standalone and swarm deployments

## Problem

Traefik uses the Lego library for ACME certificates. Lego requires `CF_DNS_API_TOKEN` or `CF_DNS_API_TOKEN_FILE` for Cloudflare DNS challenges, not `CF_API_TOKEN_FILE`.

Reference: https://go-acme.github.io/lego/dns/cloudflare/

## Testing

Generated templates now correctly pass the Cloudflare API token to Traefik.

Closes #1515