### PR TITLE
Gracefully handle missing 'needs' dependencies

### DIFF
--- a/cli/core/template/variable_collection.py
+++ b/cli/core/template/variable_collection.py
@@ -276,10 +276,13 @@ class VariableCollection:
         return actual is not None and str(actual) == str(expected)
 
     def _validate_dependencies(self) -> None:
-        """Validate section dependencies for cycles and missing references.
+        """Validate section dependencies for cycles.
+
+        Missing section references are logged as warnings but do not raise errors,
+        allowing templates to be modified without breaking when dependencies are removed.
 
         Raises:
-            ValueError: If circular dependencies or missing section references are found
+            ValueError: If circular dependencies are found
         """
         # Check for missing dependencies in sections
         for section_key, section in self._sections.items():
@@ -289,9 +292,9 @@ class VariableCollection:
                 if expected_value is None:
                     # Old format: validate section exists
                     if var_or_section not in self._sections:
-                        raise ValueError(
+                        logger.warning(
                             f"Section '{section_key}' depends on '{var_or_section}', "
-                            f"but '{var_or_section}' does not exist"
+                            f"but '{var_or_section}' does not exist. Ignoring this dependency."
                         )
                 # New format: validate variable exists
                 # NOTE: We only warn here, not raise an error, because the variable might be


### PR DESCRIPTION
## Description

Fixes #1428

When a section's `needs` dependency references a non-existent section, the CLI now logs a warning instead of raising an error. This allows templates to be modified without breaking when dependencies are removed.

## Changes

- Modified `_validate_dependencies()` in `cli/core/template/variable_collection.py` to log a warning instead of raising `ValueError` when a section dependency references a missing section
- Updated docstring to reflect the new behavior
- Missing dependencies are still handled gracefully at runtime by the existing `_check_section_need()` method

## Testing

- [x] CLI still initializes and runs correctly
- [x] Code formatted with `ruff format`
- [x] No new linting errors introduced

## Impact

This change improves the developer experience by allowing templates to evolve without strict dependency validation errors, while still logging warnings for awareness.