### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-22
+
 ### Added
 - `template.json` runtime support with required `files/` directories, custom `<< >>` / `<% %>` / `<# #>` delimiters, and legacy-format rejection for `0.2.0` (#1768)
 - Remote generation destinations via `generate --remote` and `--remote-path`, including SSH host discovery and SCP upload flow (#1765)
@@ -122,7 +124,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial public release with core CLI functionality.
 
-[unreleased]: https://github.com/christianlempa/boilerplates/compare/v0.1.2...HEAD
+[unreleased]: https://github.com/christianlempa/boilerplates/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/christianlempa/boilerplates/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/christianlempa/boilerplates/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/christianlempa/boilerplates/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/christianlempa/boilerplates/compare/v0.0.7...v0.1.0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -371,6 +371,6 @@ Uninstall:
 EOF
 }
 
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+if [[ "${BASH_SOURCE[0]-$0}" == "$0" ]]; then
   main "$@"
 fi

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -35,3 +35,18 @@ printf '%s\\n%s\\n%s\\n' "$INSTALL_VERSION" "$DISTRO_ID" "$DISTRO_VERSION"
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.splitlines() == ["latest", "ubuntu", "24.04"]
+
+
+def test_install_script_runs_from_stdin_with_nounset() -> None:
+    """Regression test for stdin execution via `curl ... | bash`."""
+    result = subprocess.run(
+        ["bash", "-s", "--", "--help"],
+        cwd=REPO_ROOT,
+        input=INSTALL_SCRIPT.read_text(encoding="utf-8"),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Install the boilerplates CLI from GitHub releases via pipx." in result.stdout


### PR DESCRIPTION
## Summary
This final release PR refreshes `release/v0.2.0` from current `main` and finalizes the changelog metadata for the `v0.2.0` release.

## Changes
- fast-forward `release/v0.2.0` to current `main`
- move the current `Unreleased` notes into `## [0.2.0] - 2026-04-22`
- update changelog compare links so the tag workflow publishes the correct release notes

## Release Impact
- `pyproject.toml` and `cli/__init__.py` already match `0.2.0`
- after this PR is merged, push tag `v0.2.0` to trigger `.github/workflows/release-create-cli-release.yaml`

## Validation
- verified release workflow expects matching tag / `pyproject.toml` / `cli/__init__.py` versions
- no additional test run in this PR because the diff is release metadata only