### PR TITLE
Add static template kind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ The project is stored in a public GitHub Repository, use issues, and branches fo
 - `helm`
 - `kubernetes`
 - `packer`
+- `static`
 - `swarm`
 - `terraform`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Static template kind for technology-agnostic file and directory boilerplates (#1786)
 - `template.json` runtime support with required `files/` directories, custom `<< >>` / `<% %>` / `<# #>` delimiters, and legacy-format rejection for `0.2.0` (#1768)
 - Remote generation destinations via `generate --remote` and `--remote-path`, including SSH host discovery and SCP upload flow (#1765)
 - Initial dedicated `swarm` module and validation flow as groundwork for the `compose` / `swarm` split in `0.2.0` (#1766)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Static template kind for technology-agnostic file and directory boilerplates (#1786)
+- Named generation output paths via `generate --name` / `-n` (#1783)
 - `template.json` runtime support with required `files/` directories, custom `<< >>` / `<% %>` / `<# #>` delimiters, and legacy-format rejection for `0.2.0` (#1768)
 - Remote generation destinations via `generate --remote` and `--remote-path`, including SSH host discovery and SCP upload flow (#1765)
 - Initial dedicated `swarm` module and validation flow as groundwork for the `compose` / `swarm` split in `0.2.0` (#1766)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Create reusable templates and turn them into configurable workloads for homelabs
 
 ## How it works
 
-Create reusable templates for infrastructure expertise like Docker, Kubernetes, Terraform, Ansible, Python, and more. Use the built-in *Jinja2-like* templating syntax with `<< >>` variables, `<% %>` blocks, and `<# #>` comments to keep configuration modular and conditional. Sync with Git in both directions or manage everything locally. Render templates, configure variables through a guided wizard, and wire up secrets. Copy them to remote servers and environments or any local directory.
+Create reusable templates for infrastructure expertise like Docker, Kubernetes, Terraform, Ansible, static files, Python, and more. Use the built-in *Jinja2-like* templating syntax with `<< >>` variables, `<% %>` blocks, and `<# #>` comments to keep configuration modular and conditional. Sync with Git in both directions or manage everything locally. Render templates, configure variables through a guided wizard, and wire up secrets. Copy them to remote servers and environments or any local directory.
 
 ✨ Explore 100+ template presets for homelabs and self-hosted infrastructure: https://github.com/ChristianLempa/boilerplates-library
 
@@ -67,8 +67,11 @@ boilerplates --help
 # Update Repository Library
 boilerplates repo update
 
-# List all available templates for a docker compose
+# List all available templates for a Docker Compose stack
 boilerplates compose list
+
+# List technology-agnostic static file templates
+boilerplates static list
 
 # Show details about a specific template
 boilerplates compose show nginx

--- a/cli/modules/static/__init__.py
+++ b/cli/modules/static/__init__.py
@@ -1,0 +1,14 @@
+"""Static templates module."""
+
+from ...core.module import Module
+from ...core.registry import registry
+
+
+class StaticModule(Module):
+    """Static templates module."""
+
+    name = "static"
+    description = "Manage static file templates"
+
+
+registry.register(StaticModule)

--- a/tests/test_static_module.py
+++ b/tests/test_static_module.py
@@ -1,0 +1,20 @@
+"""Tests for the static template module."""
+
+from __future__ import annotations
+
+import cli.modules.static  # noqa: F401 - import registers the module
+from cli.core.registry import registry
+from cli.modules.static import StaticModule
+
+
+def test_static_module_metadata() -> None:
+    """The static module should expose the expected CLI metadata."""
+    assert StaticModule.name == "static"
+    assert StaticModule.description == "Manage static file templates"
+
+
+def test_static_module_registers_with_registry() -> None:
+    """Importing the module should make the static kind discoverable."""
+    registered_modules = dict(registry.iter_module_classes())
+
+    assert registered_modules["static"] is StaticModule


### PR DESCRIPTION
## Summary
- add the `static` CLI module kind
- document static templates in README and supported kinds guidance
- add tests and changelog entries for static kind and named output paths

## Verification
- `python -m pytest`
- `ruff check .`
- `ruff format --check .`
- local static kind smoke test (`list`, `show`, `validate`, `generate --no-interactive`)

Closes #1786


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `static` template kind to the CLI for technology-agnostic file and directory boilerplates. Implements #1786 so users can list, inspect, validate, and generate static templates.

- **New Features**
  - Registers a `static` module with the CLI registry and metadata.
  - Updates README with `boilerplates static list` example and adds `static` to supported kinds.
  - Adds tests for module registration and metadata; updates CHANGELOG with the `static` kind and `generate --name` named output paths.

<sup>Written for commit 58644a71d8eea0ac027f1a06a444eb33710fb3a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

