### PR TITLE
feat(bash): add template kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Bash template kind for Bash-oriented scripts, bootstrap flows, maintenance tasks, and automation snippets (#1772)
 - Python template kind for Python-oriented project scaffolds, automation helpers, packages, and service/tooling skeletons (#1773)
 - Static template kind for technology-agnostic file and directory boilerplates (#1786)
 - Named generation output paths via `generate --name` / `-n` (#1783)

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ It combines template-defined variables and defaults, guided interactive prompts,
 
 ### Template kinds
 
-Use a dedicated kind when the template's primary output matches that technology. Use `python` for Python-oriented project scaffolds, automation helpers, packages, and service/tooling skeletons. Keep Python files inside another kind, such as `compose` or `terraform`, when they are only supporting files for that primary infrastructure template.
+Use a dedicated kind when the template's primary output matches that technology. Use `python` for Python-oriented project scaffolds, automation helpers, packages, and service/tooling skeletons. Use `bash` for Bash-oriented scripts, bootstrap flows, maintenance tasks, and automation snippets. Keep Python or Bash files inside another kind, such as `compose` or `terraform`, when they are only supporting files for that primary infrastructure template.
 
-Initial `python` validation is intentionally minimal: the CLI validates template syntax, declared variables, rendering, and generic semantic checks where applicable. Python-specific validation such as compilation, formatting, or test execution can be added as a follow-up once template conventions are established.
+Initial `python` and `bash` validation is intentionally minimal: the CLI validates template syntax, declared variables, rendering, and generic semantic checks where applicable. Language-specific validation such as Python compilation, shell syntax checks, formatting, or test execution can be added as follow-up work once template conventions are established.
 
 ### Installation
 

--- a/cli/modules/bash/__init__.py
+++ b/cli/modules/bash/__init__.py
@@ -1,0 +1,14 @@
+"""Bash templates module."""
+
+from ...core.module import Module
+from ...core.registry import registry
+
+
+class BashModule(Module):
+    """Bash templates module."""
+
+    name = "bash"
+    description = "Manage Bash script and automation templates"
+
+
+registry.register(BashModule)

--- a/tests/test_bash_module.py
+++ b/tests/test_bash_module.py
@@ -1,0 +1,20 @@
+"""Tests for the Bash template module."""
+
+from __future__ import annotations
+
+import cli.modules.bash  # noqa: F401 - import registers the module
+from cli.core.registry import registry
+from cli.modules.bash import BashModule
+
+
+def test_bash_module_metadata() -> None:
+    """The Bash module should expose the expected CLI metadata."""
+    assert BashModule.name == "bash"
+    assert BashModule.description == "Manage Bash script and automation templates"
+
+
+def test_bash_module_registers_with_registry() -> None:
+    """Importing the module should make the Bash kind discoverable."""
+    registered_modules = dict(registry.iter_module_classes())
+
+    assert registered_modules["bash"] is BashModule


### PR DESCRIPTION
## Summary
- add a first-class bash module/kind
- document bash kind boundaries and initial validation strategy
- add registry coverage for the new module
- update the changelog for #1772

Closes #1772

## Testing
- .venv/bin/ruff check --fix .
- .venv/bin/ruff format .
- .venv/bin/python -m pytest -q
- cubic review -j

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a first-class `bash` template kind to generate and manage Bash scripts and automation, aligning with #1772. It registers a new module, documents minimal validation, and adds tests.

- **New Features**
  - Introduce `bash` module and register it with the CLI registry.
  - Add tests verifying module metadata and registry discovery.
  - Update docs (README and CHANGELOG) to define `bash` usage and clarify minimal validation for `python` and `bash`.

<sup>Written for commit 26281f3fa918d1a3bb15794d868450a18c53c205. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

