### PR TITLE
feat: Added acme provider desec.io

### DIFF
--- a/library/compose/traefik/.env.j2
+++ b/library/compose/traefik/.env.j2
@@ -17,5 +17,7 @@ AZURE_CLIENT_ID={{ traefik_tls_acme_token }}
 AZURE_CLIENT_SECRET={{ traefik_tls_acme_secret_key }}
 {% elif traefik_tls_certresolver == 'namecheap' %}
 NAMECHEAP_API_KEY={{ traefik_tls_acme_token }}
+{% elif traefik_tls_certresolver == 'desec' %}
+DESEC_TOKEN={{ traefik_tls_acme_token }}
 {% endif %}
 {% endif %}

--- a/library/compose/traefik/compose.yaml.j2
+++ b/library/compose/traefik/compose.yaml.j2
@@ -147,6 +147,16 @@ services:
       {% endif %}
       - NAMECHEAP_API_USER={{ traefik_tls_acme_username }}
       {% endif %}
+      {% elif traefik_tls_certresolver == 'desec' %}
+      {% if swarm_enabled %}
+      - DESEC_TOKEN=/run/secrets/{{ service_name }}_token
+      {% else %}
+      - DESEC_TOKEN=${DESEC_TOKEN}
+      {% endif %}
+      - DESEC_HTTP_TIMEOUT=600
+      - DESEC_PROPAGATION_TIMEOUT=2400
+      - DESEC_TTL=3600
+      - DESEC_POLLING_INTERVAL=60
       {% endif %}
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8082/ping"]

--- a/library/compose/traefik/template.yaml
+++ b/library/compose/traefik/template.yaml
@@ -104,8 +104,8 @@ spec:
         description: DNS provider API token
         type: secret
         required: true
-        needs: ['traefik_tls_certresolver=cloudflare,digitalocean,godaddy,namecheap,porkbun']
-        extra: CF_DNS_API_TOKEN, DO_AUTH_TOKEN, GODADDY_API_KEY, NAMECHEAP_API_KEY, or PORKBUN_API_KEY
+        needs: ['traefik_tls_certresolver=cloudflare,digitalocean,godaddy,namecheap,porkbun,desec']
+        extra: CF_DNS_API_TOKEN, DO_AUTH_TOKEN, GODADDY_API_KEY, NAMECHEAP_API_KEY, PORKBUN_API_KEY or DESEC_KEY
       traefik_tls_acme_username:
         description: Namecheap API username
         type: str
@@ -114,7 +114,7 @@ spec:
       traefik_tls_certresolver:
         description: ACME DNS challenge provider
         config:
-          options: [cloudflare, porkbun, godaddy, digitalocean, route53, azure, namecheap]
+          options: [cloudflare, porkbun, godaddy, digitalocean, route53, azure, namecheap, desec]
         extra: DNS provider for domain validation
       traefik_tls_enabled:
         description: Enable HTTPS/TLS with ACME


### PR DESCRIPTION
### Pull Request


Adds desec.io as acme provider for traefik.

This adds the following values to the traefik compose file:

      - DESEC_TOKEN=${DESEC_TOKEN}
      - DESEC_HTTP_TIMEOUT=600
      - DESEC_PROPAGATION_TIMEOUT=2400
      - DESEC_TTL=3600
      - DESEC_POLLING_INTERVAL=60

It adds the following values to the .env file:

    - DESEC_TOKEN={{ traefik_tls_acme_token }}



I have not tested the swarm implementation but the normal generated docker compose file works on my machine™

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `desec.io` as an ACME DNS provider for `traefik`, including token wiring and default DNS challenge timeouts.

- **New Features**
  - Support `desec` in `traefik_tls_certresolver` options.
  - Token via `DESEC_TOKEN` (from `.env`) or `/run/secrets/<service>_token` on Swarm.
  - Default envs added: `DESEC_HTTP_TIMEOUT=600`, `DESEC_PROPAGATION_TIMEOUT=2400`, `DESEC_TTL=3600`, `DESEC_POLLING_INTERVAL=60`.
  - Template updated to require an ACME token when `traefik_tls_certresolver=desec`.

- **Migration**
  - Set `traefik_tls_certresolver=desec`.
  - Provide the token via `traefik_tls_acme_token` (maps to `DESEC_TOKEN`) or create the Swarm secret `<service>_token`.

<sup>Written for commit c52664ec46c1b16fab09045688f9dbc050a65885. Summary will update on new commits. <a href="https://cubic.dev/pr/ChristianLempa/boilerplates/pull/1793?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

