### PR TITLE
Added missing pip packages to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ rich==14.2.0
 PyYAML==6.0.3
 python-frontmatter==1.1.0
 Jinja2==3.1.6
+click==8.1.4


### PR DESCRIPTION
Think you missed adding some of the packages to the requirements.txt, so when you install it you would get missing packages. Might be useful to use uv and an action to track the dependencies (new to actual project management, so there is probably a better way.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `click==8.1.4` to `requirements.txt` so installs include the CLI dependency and avoid import errors. Fixes setup failures on fresh environments.

<sup>Written for commit db86603439a8e633d6e6252855265d52feea3f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChristianLempa/boilerplates/pull/1794?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

