### PR TITLE
Fix Typer Context initialization crashing the CLI and missing clicker…

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -239,29 +239,27 @@ def run() -> None:
         except (ValueError, IndexError):
             pass  # Let Typer handle argument parsing errors
 
-    init_app()
-    app()
 
-    # try:
-    #     init_app()
-    #     app()
-    # except (ValueError, RuntimeError) as e:
-    #     # Handle configuration and initialization errors cleanly
-    #     display.error(str(e))
-    #     sys.exit(1)
-    # except ImportError as e:
-    #     # Handle module import errors with detailed info
-    #     display.error(f"Module Import Error: {e}")
-    #     sys.exit(1)
-    # except KeyboardInterrupt:
-    #     # Handle Ctrl+C gracefully
-    #     display.warning("Operation cancelled by user")
-    #     sys.exit(130)
-    # except Exception as e:
-    #     # Handle unexpected errors - show simplified message
-    #     display.error(str(e))
-    #     display.info("Use --log-level DEBUG for more details")
-    #     sys.exit(1)
+    try:
+        init_app()
+        app()
+    except (ValueError, RuntimeError) as e:
+        # Handle configuration and initialization errors cleanly
+        display.error(str(e))
+        sys.exit(1)
+    except ImportError as e:
+        # Handle module import errors with detailed info
+        display.error(f"Module Import Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        # Handle Ctrl+C gracefully
+        display.warning("Operation cancelled by user")
+        sys.exit(130)
+    except Exception as e:
+        # Handle unexpected errors - show simplified message
+        display.error(str(e))
+        display.info("Use --log-level DEBUG for more details")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import click
 from rich.console import Console
-from typer import Option, Typer
+from typer import Option, Typer, Context
 from typer.core import TyperGroup
 
 import cli.modules
@@ -79,6 +79,7 @@ def setup_logging(log_level: str = "WARNING") -> None:
 
 @app.callback(invoke_without_command=True)
 def main(
+    ctx: Context,
     _version: bool | None = Option(
         None,
         "--version",
@@ -103,9 +104,6 @@ def main(
     else:
         # Silence all logging (including third-party) unless user explicitly requests it
         logging.disable(logging.CRITICAL)
-
-    # Get context without type annotation (compatible with all Typer versions)
-    ctx = click.get_current_context()
 
     # Store log level in context for potential use by other commands
     ctx.ensure_object(dict)
@@ -241,26 +239,29 @@ def run() -> None:
         except (ValueError, IndexError):
             pass  # Let Typer handle argument parsing errors
 
-    try:
-        init_app()
-        app()
-    except (ValueError, RuntimeError) as e:
-        # Handle configuration and initialization errors cleanly
-        display.error(str(e))
-        sys.exit(1)
-    except ImportError as e:
-        # Handle module import errors with detailed info
-        display.error(f"Module Import Error: {e}")
-        sys.exit(1)
-    except KeyboardInterrupt:
-        # Handle Ctrl+C gracefully
-        display.warning("Operation cancelled by user")
-        sys.exit(130)
-    except Exception as e:
-        # Handle unexpected errors - show simplified message
-        display.error(str(e))
-        display.info("Use --log-level DEBUG for more details")
-        sys.exit(1)
+    init_app()
+    app()
+
+    # try:
+    #     init_app()
+    #     app()
+    # except (ValueError, RuntimeError) as e:
+    #     # Handle configuration and initialization errors cleanly
+    #     display.error(str(e))
+    #     sys.exit(1)
+    # except ImportError as e:
+    #     # Handle module import errors with detailed info
+    #     display.error(f"Module Import Error: {e}")
+    #     sys.exit(1)
+    # except KeyboardInterrupt:
+    #     # Handle Ctrl+C gracefully
+    #     display.warning("Operation cancelled by user")
+    #     sys.exit(130)
+    # except Exception as e:
+    #     # Handle unexpected errors - show simplified message
+    #     display.error(str(e))
+    #     display.info("Use --log-level DEBUG for more details")
+    #     sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/cli/core/module/helpers.py
+++ b/cli/core/module/helpers.py
@@ -194,10 +194,7 @@ def apply_cli_overrides(template, var: list[str] | None, ctx=None) -> None:
 
     # Get context if not provided (compatible with all Typer versions)
     if ctx is None:
-        try:
-            ctx = click.get_current_context()
-        except RuntimeError:
-            ctx = None
+        ctx = click.get_current_context(silent=True)
 
     extra_args = list(ctx.args) if ctx and hasattr(ctx, "args") else []
     cli_overrides = parse_var_inputs(var or [], extra_args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "python-frontmatter>=1.0.0",
     "Jinja2>=3.0",
     "email-validator>=2.0.0",
+    "click==8.1.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
… requiremnt in pipx toml.

### Pull Request

This fixes a bug where the CLI crashes immediately any command is executed.

Changes:

- Added missing clicker requirement to pipx toml
- Swapped click.Context for Typer's Context in main() so Typer injects it correctly instead of trying to parse it as a flag.
- Removed the manual click.get_current_context() call in main() which was triggering the crash before Typer was ready.
- Added silent=True to the context fetch in apply_cli_overrides so it fails gracefully instead of bubbling up an error.

Tested locally with pipx and it runs perfectly now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a CLI crash on every command by using `Typer.Context` correctly and adding the missing `click` dependency. Commands now run without Typer parsing errors, and context lookups fail gracefully when absent.

- **Bug Fixes**
  - Accept `ctx: Typer.Context` in `main()` so Typer injects it; removed manual `click.get_current_context()` that triggered early crashes.
  - Use `click.get_current_context(silent=True)` in `apply_cli_overrides` to avoid `RuntimeError` when no context is available.
  - Restore try/except in `run()` to let Typer handle argument parsing errors without crashing.

- **Dependencies**
  - Add `click==8.1.4` to `pyproject.toml` for `pipx` installs.

<sup>Written for commit 09fcc7fc3efeb945dea02f43e12d6cd6fbd8fe81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChristianLempa/boilerplates/pull/1796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

