### PR TITLE
update repository

### DIFF
--- a/library/ansible/docker-install-ubuntu/main.yml.j2
+++ b/library/ansible/docker-install-ubuntu/main.yml.j2
@@ -1,16 +1,8 @@
 ---
-- name: {{ playbook_name }}
+- name: Install Docker on Ubuntu
   hosts: {{ target_hosts }}
-{% if become %}
   become: true
-{% endif %}
-{% if options_enabled and not gather_facts %}
-  gather_facts: false
-{% endif %}
-{% if secrets_enabled %}
-  vars_files:
-    - {{ secrets_file }}
-{% endif %}
+  gather_facts: true
 
   tasks:
     - name: Install docker dependencies
@@ -32,7 +24,7 @@
     - name: Add docker repository
       ansible.builtin.apt_repository:
         filename: docker
-        repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu {{ '{{' }} ansible_lsb.codename | lower {{ '}}' }} stable
+        repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu {% verbatim %}{{ ansible_lsb.codename | lower }}{% endverbatim %} stable
         state: present
 
     - name: Install docker engine

--- a/library/ansible/docker-install-ubuntu/template.yaml
+++ b/library/ansible/docker-install-ubuntu/template.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   general:
     vars:
-      playbook_name:
-        default: Install docker
-      become:
-        default: true
+      target_hosts:
+        type: string
+        default: all
+        description: Target hosts for the Ansible playbook.

--- a/library/compose/adguardhome/compose.yaml.j2
+++ b/library/compose/adguardhome/compose.yaml.j2
@@ -20,18 +20,19 @@ services:
     {#
       Port mappings (only in bridge mode or default network):
       - HTTP/HTTPS (80/443) ports are only exposed when Traefik is disabled
-      - Initial setup port 3000 is exposed during first-time setup
+      - Initial setup port 3000 is exposed during first-time setup (when not using Traefik)
       - DNS and related ports (53, 853, 5443) are always exposed
       - In host or macvlan mode, ports are bound directly to host network
+      Note: When using Traefik, access initial setup via container IP:3000 before DNS is configured
     #}
-    {% if network_mode == '' or network_mode == 'bridge' or traefik_enabled %}
+    {% if not network_mode or network_mode == 'bridge' or traefik_enabled %}
     ports:
       {% if not traefik_enabled %}
       - "{{ ports_http }}:80/tcp"
       - "{{ ports_https }}:443/tcp"
+      {% endif %}
       {% if initial_setup %}
       - "{{ ports_initial }}:3000/tcp"
-      {% endif %}
       {% endif %}
       - "{{ ports_https }}:443/udp"
       - "{{ ports_dns }}:53/tcp"
@@ -57,28 +58,15 @@ services:
       - traefik.enable=true
       - traefik.docker.network={{ traefik_network }}
       - traefik.http.services.{{ service_name }}_web.loadBalancer.server.port=80
-      - traefik.http.routers.{{ service_name }}_http.service={{ service_name }}_web
-      - traefik.http.routers.{{ service_name }}_http.rule=Host(`{{ traefik_host }}.{{ traefik_domain }}`)
-      - traefik.http.routers.{{ service_name }}_http.entrypoints=web
+      - traefik.http.routers.{{ service_name }}_web_http.service={{ service_name }}_web
+      - traefik.http.routers.{{ service_name }}_web_http.rule=Host(`{{ traefik_host }}.{{ traefik_domain }}`)
+      - traefik.http.routers.{{ service_name }}_web_http.entrypoints=web
       {% if traefik_tls_enabled %}
-      - traefik.http.routers.{{ service_name }}_https.service={{ service_name }}_web
-      - traefik.http.routers.{{ service_name }}_https.rule=Host(`{{ traefik_host }}.{{ traefik_domain }}`)
-      - traefik.http.routers.{{ service_name }}_https.entrypoints=websecure
-      - traefik.http.routers.{{ service_name }}_https.tls=true
-      - traefik.http.routers.{{ service_name }}_https.tls.certresolver={{ traefik_tls_certresolver }}
-      {% endif %}
-      {#
-        Initial setup routing (port 3000):
-        Routes setup wizard through separate Traefik service.
-        Note: Setup wizard is available at http://<host>.<domain>/setup during initial configuration.
-      #}
-      {% if initial_setup %}
-      - traefik.http.services.{{ service_name }}_setup.loadBalancer.server.port=3000
-      - traefik.http.routers.{{ service_name }}_setup.service={{ service_name }}_setup
-      - traefik.http.routers.{{ service_name }}_setup.rule=Host(`{{ traefik_host }}.{{ traefik_domain }}`) && PathPrefix(`/setup`)
-      - traefik.http.routers.{{ service_name }}_setup.entrypoints=web
-      - traefik.http.middlewares.{{ service_name }}_setup-strip.stripprefix.prefixes=/setup
-      - traefik.http.routers.{{ service_name }}_setup.middlewares={{ service_name }}_setup-strip
+      - traefik.http.routers.{{ service_name }}_web_https.service={{ service_name }}_web
+      - traefik.http.routers.{{ service_name }}_web_https.rule=Host(`{{ traefik_host }}.{{ traefik_domain }}`)
+      - traefik.http.routers.{{ service_name }}_web_https.entrypoints=websecure
+      - traefik.http.routers.{{ service_name }}_web_https.tls=true
+      - traefik.http.routers.{{ service_name }}_web_https.tls.certresolver={{ traefik_tls_certresolver }}
       {% endif %}
     {% endif %}
 
@@ -108,9 +96,6 @@ networks:
         - subnet: {{ network_macvlan_subnet }}
           gateway: {{ network_macvlan_gateway }}
     name: {{ network_name }}
-    {% elif swarm_enabled %}
-    driver: overlay
-    attachable: true
     {% else %}
     driver: bridge
     {% endif %}

--- a/library/compose/adguardhome/compose.yaml.j2
+++ b/library/compose/adguardhome/compose.yaml.j2
@@ -17,14 +17,6 @@ services:
       {{ network_name }}:
       {% endif %}
     {% endif %}
-    {#
-      Port mappings (only in bridge mode or default network):
-      - HTTP/HTTPS (80/443) ports are only exposed when Traefik is disabled
-      - Initial setup port 3000 is exposed during first-time setup (when not using Traefik)
-      - DNS and related ports (53, 853, 5443) are always exposed
-      - In host or macvlan mode, ports are bound directly to host network
-      Note: When using Traefik, access initial setup via container IP:3000 before DNS is configured
-    #}
     {% if not network_mode or network_mode == 'bridge' or traefik_enabled %}
     ports:
       {% if not traefik_enabled %}
@@ -71,16 +63,6 @@ services:
     {% endif %}
 
 {% if network_mode == 'bridge' or network_mode == 'macvlan' or traefik_enabled %}
-{#
-  Network definitions:
-  - 'bridge' mode: creates custom bridge network
-  - 'macvlan' mode: creates macvlan network with static IP assignment
-    (requires manual network creation in Swarm mode)
-  - Swarm overlay: used when swarm_enabled=true with bridge mode
-  - Traefik network: always external (managed separately by Traefik stack)
-  - Default mode (network_mode=''): uses Docker's default bridge (no definition needed)
-  - Host mode: no network definition (container uses host network stack directly)
-#}
 networks:
   {% if network_mode == 'bridge' or network_mode == 'macvlan'%}
   {{ network_name }}:
@@ -108,12 +90,6 @@ networks:
 {% endif %}
 
 {% if volume_mode == 'local' %}
-{#
-  Volume definitions:
-  - 'local' mode: Docker-managed local volumes
-  - 'nfs' mode: NFS-backed volumes for shared storage
-  - 'mount' mode: bind mounts (no volume definition needed)
-#}
 volumes:
   {{ service_name }}_work:
     driver: local

--- a/library/compose/adguardhome/template.yaml
+++ b/library/compose/adguardhome/template.yaml
@@ -8,8 +8,10 @@ metadata:
     It features advanced DNS filtering, parental controls, safe browsing, and HTTPS/DNS-over-TLS/DNS-over-QUIC support.
     ## Prerequisites
     - :info: During the initial setup, AdGuard Home runs an HTTP server on port 3000 to guide you through configuration.
-    After completing the setup, AdGuard Home switches to the configured HTTP port, and port, consider re-deploying the
-    service with `initial_setup=false`.
+    **With Traefik enabled:** Access initial setup via container IP at `http://<container-ip>:3000`.
+    After setup completes, access the admin interface via the configured domain.
+    - :warning: **Security Notice:** The initial setup on port 3000 uses an unencrypted HTTP connection.
+    Only use this for initial configuration and disable it (`initial_setup=false`) after setup is complete.
     - :warning: If you require DHCP functionality or want AdGuard Home to bind directly to port 53,
     you must set `network_mode` to `host` or `macvlan`. Note this exposes all container ports directly on the host.
     You can't use `traefik_enabled` in this case!
@@ -28,33 +30,31 @@ metadata:
     - network
     - volume
   next_steps:
-  draft: true
 schema: 1.2
 spec:
   general:
     vars:
       service_name:
-        default: "adguardhome"
+        default: adguardhome
       initial_setup:
-        description: "Enable initial setup wizard on port 3000"
+        description: Enable initial setup wizard on port 3000 (only used without Traefik)
         type: bool
         default: true
         extra: >
-          Port 3000 is only used during the initial setup wizard.
-          After completing setup, AdGuard Home switches to the configured HTTP port and port 3000 becomes inactive.
-          Set to false if you've already completed the initial setup.
+          Port 3000 is only used during the initial setup wizard when Traefik is disabled.
+          With Traefik enabled, access setup via container IP instead.
+          After completing setup, AdGuard Home switches to port 80 and port 3000 becomes inactive.
   traefik:
     vars:
       traefik_host:
-        default: "adguardhome"
+        default: adguardhome
   network:
     vars:
       network_mode:
         extra: >
           Use 'host' mode if you need DHCP functionality or want AdGuard Home to bind directly to port 53.
-          NOTE: Swarm only supports 'bridge' mode!
       network_name:
-        default: "adguardhome_network"
+        default: adguardhome_network
   ports:
     vars:
       ports_http:
@@ -62,21 +62,20 @@ spec:
       ports_https:
         default: 443
       ports_initial:
-        description: "Initial setup wizard port"
+        description: Initial setup wizard port (only when Traefik is disabled)
         type: int
         default: 3000
         needs: ["traefik_enabled=false", "initial_setup=true"]
         extra: >
-          Only used during first-time setup. After configuration, port becomes inactive.
-      ports_dns:
-        description: "DNS port"
-        type: int
-        default: 53
+          Only used during first-time setup without Traefik. After configuration, port becomes inactive.
+          With Traefik, access setup via container IP instead.
       ports_tls:
-        description: "DNS over TLS Port"
+        description: DNS over TLS Port
         type: int
         default: 853
+        required: true
       ports_dnscrypt:
-        description: "DNSCrypt Port"
+        description: DNSCrypt Port
         type: int
         default: 5443
+        required: true

--- a/library/compose/gitea/compose.yaml.j2
+++ b/library/compose/gitea/compose.yaml.j2
@@ -1,6 +1,6 @@
 services:
   {{ service_name }}:
-    image: docker.io/gitea/gitea:1.25.2
+    image: docker.io/gitea/gitea:1.25.3
     restart: {{ restart_policy }}
     environment:
       - USER_UID={{ user_uid }}

--- a/library/compose/gitea/template.yaml
+++ b/library/compose/gitea/template.yaml
@@ -17,9 +17,9 @@ metadata:
   icon:
     provider: selfh
     id: gitea
-  version: 1.25.2
+  version: 1.25.3
   author: Christian Lempa
-  date: '2025-12-10'
+  date: '2025-12-19'
   tags:
     - traefik
 schema: 1.2

--- a/library/compose/homeassistant/compose.yaml.j2
+++ b/library/compose/homeassistant/compose.yaml.j2
@@ -1,7 +1,7 @@
 services:
   {{ service_name }}:
     container_name: {{ container_name }}
-    image: ghcr.io/home-assistant/home-assistant:2025.12.3
+    image: ghcr.io/home-assistant/home-assistant:2025.12.4
     volumes:
       - ./config:/config
       - /etc/localtime:/etc/localtime:ro

--- a/library/compose/homeassistant/template.yaml
+++ b/library/compose/homeassistant/template.yaml
@@ -8,9 +8,9 @@ metadata:
 
     Project: https://www.home-assistant.io/
     Documentation: https://www.home-assistant.io/docs/
-  version: 2025.12.3
+  version: 2025.12.4
   author: Christian Lempa
-  date: '2025-12-12'
+  date: '2025-12-19'
   tags: []
   icon:
     provider: selfh

--- a/library/compose/n8n/compose.yaml.j2
+++ b/library/compose/n8n/compose.yaml.j2
@@ -31,7 +31,7 @@ services:
 
   {% endif -%}
   {{ service_name }}:
-    image: n8nio/n8n:2.1.1
+    image: n8nio/n8n:2.1.2
     {% if not swarm_enabled -%}
     container_name: {{ container_name }}
     hostname: {{ container_hostname }}
@@ -185,7 +185,7 @@ services:
 {% if queue_enabled and queue_embedded_worker -%}
 
   {{ service_name }}-worker:
-    image: n8nio/n8n:2.1.1
+    image: n8nio/n8n:2.1.2
     command: worker
     {% if not swarm_enabled -%}
     container_name: {{ container_name }}-worker


### PR DESCRIPTION
### Pull Request

*Please write all text in English in order to facilitate communication and collaboration. Thank you!*

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlines the Ubuntu Docker Ansible playbook and simplifies the AdGuard Home compose/Traefik setup. Also bumps `docker.io/gitea/gitea` to 1.25.3, `ghcr.io/home-assistant/home-assistant` to 2025.12.4, and `n8nio/n8n` to 2.1.2.

- **Refactors**
  - Ansible (Ubuntu Docker install): simpler playbook with `become: true`, `gather_facts: true`, fixed apt repo Jinja rendering, and a new `target_hosts` var (default `all`).
  - AdGuard Home compose: cleaned up port logic and networks, updated Traefik router labels to `..._web_http` and `..._web_https`, removed the `/setup` Traefik route, and clarified setup docs and security notes. TLS/DNSCrypt port vars are now required.

- **Migration**
  - If you reference Traefik router names, update to `traefik.http.routers.<service>_web_http` and `..._web_https`.
  - AdGuard Home with Traefik: complete initial setup via `http://<container-ip>:3000`, then set `initial_setup=false`.
  - Ansible users: pass `target_hosts` instead of older vars; it defaults to `all`.

<sup>Written for commit 39614f88e7cc427af17b323523ce26a02164935d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChristianLempa/boilerplates/pull/1798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

